### PR TITLE
updated event tracker methods and validations

### DIFF
--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -12,10 +12,14 @@ import { AppState } from 'react-native';
  * @description The `EventTracker` class provides functionality for managing events, including adding new events,
  *              validating event sequences, and retrieving event data. It interacts with the `Database` class to
  *              perform operations on the event records.
- * @param {string} filename - The name of the database file used by the `EventTracker` instance.
  */
 
+
 class EventTracker{
+
+    /**
+     * @param {string} filename - The name of the database file used by the `EventTracker` instance.
+     */
 
     constructor(filename) {
         this.db = new Database(filename);
@@ -27,7 +31,7 @@ class EventTracker{
      * 
      * @async
      * @name addEvent
-     * @param {object} params
+     * @param {{id: string, type: string, time: string, payload: object}} params
      * @param {string} params.id 
      * @param {"start"|"pause"|"resume"|"finish"}  params.type
      * @param {string} params.time current time in isoString format
@@ -158,16 +162,18 @@ class EventTracker{
             if(!events?.length) throw new EventTrackerError('ID was not tracked');
 
             const startEvent = events.find((e) => e.type === 'start');
-            const endEvent = events.find((e) => e.type === 'finish');
 
             if(!startEvent || !Object.keys(startEvent).length) throw new EventTrackerError('ID was not tracked')
 
+            const endEvents = events.filter((e) => e.type === 'finish');
+            const lastEndEvent = Helpers.reverseArray(endEvents)[0]
+
             const startTime = startEvent.time;
-            const currentTime = !!endEvent?.time ?  endEvent.time : new Date().toISOString();
+            const currentTime = !!lastEndEvent?.time ?  lastEndEvent.time : new Date().toISOString();
 
             const elapsedTime = Helpers.getTimeDifference(startTime, currentTime);
 
-            return elapsedTime
+            return elapsedTime;
 
         } catch (error) {
             return Promise.reject(error);
@@ -216,15 +222,27 @@ class EventTracker{
      * @returns {Promise<Array<string|null>>} A promise that resolves to an array of saved timer events or `null` if no IDs are found.
      * @throws {EventTrackerError} If an error occurs while retrieving IDs or saving events.
      */
-
+    
     async _stopEventsInBackground () {
+        const stoppedTypes  = ['pause','finish'];
+        let stoppedEvents = [];
+
         try {
             const ids = await this._getAllIds()
 
-            if(!ids.length) return null;
-            let stoppedEvents = [];
+            if(!ids.length) return stoppedEvents;
 
-            for(const id of ids) {
+        for(const id of ids) {
+                const [lastEvent, lastEventError] = await Helpers.promiseWrapper(
+                    this.getLastEventById(id)
+                );
+
+                if(lastEventError) {
+                    console.warn(lastEventError)
+                }
+
+                if(stoppedTypes.includes(lastEvent?.type)) continue;
+
                 const [savedEvent, saveError] = await Helpers.promiseWrapper(
                     this.addEvent({
                         id,
@@ -335,6 +353,22 @@ class EventTracker{
         try {
             await this.db.deleteAll();
         } catch(error) {
+            return Promise.reject(error);
+        }
+    }
+
+    /**
+     * Asynchronously removes a record with the specified `id` and type 'finish' from the database.
+     *
+     * @param {string} id - The unique identifier of the record to be removed.
+     * @returns {Promise<boolean>} - A promise that resolves to `true` if the deletion was successful.
+     * @throws {Error} - If an error occurs during the deletion process, the promise is rejected with the error.
+     */
+
+    async removeFinishById (id) {
+        try {
+            return await this.db.delete('id LIKE[c] $0 && type = $1', id, 'finish');
+        } catch (error) {
             return Promise.reject(error);
         }
     }

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -367,7 +367,7 @@ class EventTracker{
 
     async removeFinishById (id) {
         try {
-            return await this.db.delete('id LIKE[c] $0 && type = $1', id, 'finish');
+            return await this.db.delete('id LIKE[c] $0 && type = $1', String(id), 'finish');
         } catch (error) {
             return Promise.reject(error);
         }

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -13,14 +13,6 @@ import {isSameDay, differenceInMilliseconds} from 'date-fns';
         return !!(arr instanceof Array);
     }
 
-    /**
-     * 
-     * @param {Array} arr 
-     */
-    static reverseArray(arr) {
-        return arr.reverse()
-    }
-
     static findEventByStatus(arr, status) {
         return arr.find((value) => value?.type === status)
     }

--- a/utils/validations.js
+++ b/utils/validations.js
@@ -35,7 +35,7 @@ class Validations {
 
     static validateEventsSequence (type,previousType = '') {
 
-        if(previousType === 'finish') throw new EventTrackerError(`Forbidden event: record is already finished`)
+        if(previousType === 'finish' && type !== 'finish') throw new EventTrackerError(`Forbidden event: record is already finished`)
         switch(type) {
             case 'start': 
                 if(previousType === 'start') throw new EventTrackerError(`Forbidden event: only one start record is allowed`);


### PR DESCRIPTION
LINK DE TAREA:

https://janiscommerce.atlassian.net/browse/APPSRN-330

LINK DE SUBTAREA:

https://janiscommerce.atlassian.net/browse/APPSRN-334

DESCRIPCION DE REQUERIMIENTO:

Se requiere ajustar las validaciones del package para permitir que, una vez que se finalice el seguimiento de un id, se permita seguir agregando eventos para este siempre y cuando sean de tipo finish.
Se necesita corregir la detención en segundo plano para que sólo se aplique a eventos que se encuentren en curso.

DESCRIPCIÓN DE SOLUCIÓN:

Se modificó la condición en la validación de secuencia de eventos para que sólo se permita agregar eventos posteriores a la finalización de seguimiento si el evento a agregar es de tipo finish. Para hacer esto se valida el último tipo de evento agregado y si el evento a agregar es de tipo finish. Si es así entonces permitimos agregar nuevos eventos de finish, pero en otro escenario entonces arroja el error de que el trackeo ya fue finalizado.

Se cambió el funcionamiento de `_stopEventsInBackground` para que, antes de ejecutar la pausa sobre un evento, se valide que este se encuentre en curso: si es así, entonces se pausa el evento, pero si ya se encuentra pausado o finalizado entonces se lo ignora.

Se modificó getElapsedTime para que, cuando se haga el calculo de tiempos entre el inicio y el fin, en caso de haber más de un evento de finish, se tome como limite el último evento agregado.

También se agregó un método que permite eliminar TODOS Los registros de tipo finish asociados a un id, el método es removeFinishById, que, en caso de fallar retornará una promesa rechazada.

¿CÓMO PROBARLO?

Para probarlo se necesita vincular el package con yalc y luego instanciar la clase EventTracker dentro del repo de la app.
La clase espera un string como argumento que va a usarse como nombre del archivo .realm que se va a generar y que va a encargarse de almacenar todos los registros ingresados.

```js
import EventTrackerClass from "@janiscommerce/app-tracking-time";

const EventTracker = new EventTrackerClass('picking-times')

export default EventTracker;
```

Luego, usar la botonera para crear varios eventos:

```js
  import EventTracker from 'src/utils/eventTracker';
  import Button from 'src/components/Button';
  import { promiseWrapper } from '@janiscommerce/apps-helpers';

       const addEvent = async (id, type,time, payload) => {
		const [response, error] = await promiseWrapper(EventTracker.addEvent({id,type,time,payload}))

		console.log('error', error)
		console.log('time', response)
	}

	const getCurrentTime = async (id) => {
		const [time, error] = await promiseWrapper(EventTracker.getElapsedTimeById(id))

		console.log('error', error)
		console.log('time', time)
	}

	const getAllEvents = async (id) => {
		const [ids, error] = await promiseWrapper(EventTracker.getEventsById(id));

		console.log('error', error)
		console.log('ids', ids)
	}

	const eventWasStarted = async (id) => {
		const [event, error] = await promiseWrapper(EventTracker.isEventAlreadyStarted(id))

		console.log('error', error)
		console.log('event', event)
	}

	const deleteAll = async () => {
		const [reset,error] = await promiseWrapper(EventTracker.deleteAllEvents());

		console.log('error', error)
		console.log('reset', reset)
	}

  <>
    	<Button title={'agregar primer id'} onPress={() => addEvent('123-session','start')}/>
	<Button title={'agregar segundo id'} onPress={() => addEvent('234-session','start')}/>
	<Button title={'agregar tercer id'} onPress={() => addEvent('345-session','start')}/>
	<Button title={'pausar primer id'} onPress={() => addEvent('123-session','pause')}/>
	<Button title={'pausar segundo id'} onPress={() => addEvent('234-session','pause')}/>
        <Button title={'pausar tercer id'} onPress={() => addEvent('345-session','pause')}/>
	<Button title={'continuar primer id'} onPress={() => addEvent('123-session','resume')}/>
	<Button title={'continuar segundo id'} onPress={() => addEvent('234-session','resume')}/>
        <Button title={'continuar tercer id'} onPress={() => addEvent('345-session','resume')}/>
	<Button title={'finalizar primer id'} onPress={() => addEvent('123-session','finish')}/>
	<Button title={'finalizar segundo id'} onPress={() => addEvent('234-session','finish')}/>
        <Button title={'finalizar tercer id'} onPress={() => addEvent('345-session','finish')}/>
	<Button title={'traer todos los primer id'} onPress={() => getAllEvents('123-session')}/>
	<Button title={'traer todos los segundo id'} onPress={() => getAllEvents('234-session')}/>
	<Button title={'traer todos los tercero id'} onPress={() => getAllEvents('345-session')}/>
	<Button title={'valldar si el id 123 fue iniciado'} onPress={() => eventWasStarted('123-session')}/>
	<Button title={'valldar si el id 234 fue iniciado'} onPress={() => eventWasStarted('234-session')}/>
	<Button title={'valldar si el id 345 fue iniciado'} onPress={() => eventWasStarted('345-session')}/>
	<Button title={'borrar todo'} onPress={deleteAll}/>
	<Button title={'tiempo transcurrido primer id'} onPress={() => getCurrentTime('123-session')}/>
	<Button title={'tiempo transcurrido segundo id'} onPress={() => getCurrentTime('234-session')}/>
        <Button title={'tiempo transcurrido tercer id'} onPress={() => getCurrentTime('345-session')}/>
  </>

```

Recordar que, para pausar los eventos que van a segundo plano, se debe agregar este código en la main o la app.js

```js

import EventTracker from 'src/utils/eventTracker';

const App = () => {
	//...
	useEffect(() => {
		// Iniciar el listener cuando el componente se monta
		EventTracker.startListening();
	
		// Eliminar el listener cuando el componente se desmonta
		return () => {
		  EventTracker.stopListening();
		};
	  }, []); 
```
Si se quiere probar el método removeFinishById deberá agregar un botón más que se encargue de eliminar los registros por ID:

```js
const removeFinish = async (id) => {
  const [,error] = await promiseWrapper(EventTracker.removeFinishById(id)
 
console.log('remove error',error)

<Button title={'remove finish for 234-session'} onPress={() => removeFinish('234-session')}/>
```
