### PR TITLE
Appsrn 344 agregar metodo de borrado de base y modificacion en obtencion de tiempo transcurrido

### DIFF
--- a/__mocks__/Database.js
+++ b/__mocks__/Database.js
@@ -23,7 +23,7 @@ class Database {
       return Promise;
     }
 
-    async isFolderExist() {
+    async isFolderAvailable() {
       // Simula la llamada al método 'exists' de RNFS para validar si la carpeta existe
       return Promise;
     }

--- a/__mocks__/Database.js
+++ b/__mocks__/Database.js
@@ -5,22 +5,37 @@ class Database {
   
     async save() {
       // Simula el guardado del evento sin hacer nada
-      return Promise.resolve();
+      return Promise;
     }
   
     async search() {
-      // Simula una búsqueda, devolviendo una lista de eventos vacía o lo que necesites
-      return [];
+      // Simula una búsqueda
+      return Promise;
     }
   
     async delete() {
       // Simula la eliminación de eventos
-      return Promise.resolve();
+      return Promise;
     }
   
     async deleteAll() {
       // Simula la eliminación de todos los eventos
-      return Promise.resolve();
+      return Promise;
+    }
+
+    async isFolderExist() {
+      // Simula la llamada al método 'exists' de RNFS para validar si la carpeta existe
+      return Promise;
+    }
+
+    async removeDatabaseFolder() {
+      // Simula la eliminación de la carpeta de la base de datos mediante 'unlink' de RNFS
+      return Promise;
+    }
+
+    async createDatabaseFolder() {
+      // Simula la creación de la carpeta de la base de datos mediante 'mkdir' de RNFS;
+      return Promise;
     }
   }
   

--- a/__mocks__/events.js
+++ b/__mocks__/events.js
@@ -1,0 +1,27 @@
+export const startEvent = {
+    id:'123456',
+    time: '2023-01-01T00:00:00.000Z',
+    payload: {},
+    type: 'start',
+}
+
+export const pauseEvent = {
+    id:'123456',
+    time: '2023-01-01T00:30:00.000Z',
+    payload: {},
+    type: 'pause'
+}
+
+export const resumeEvent = {
+    id:'123456',
+    time: '2023-01-01T00:35:00.000Z',
+    payload: {},
+    type: 'resume'
+}
+
+export const finishEvent = {
+    id:'123456',
+    time: '2023-01-02T00:00:00.000Z',
+    payload: {},
+    type: 'finish',
+}

--- a/lib/database.js
+++ b/lib/database.js
@@ -9,13 +9,13 @@ class Database {
         this.filename = filename;
         this.path = `${RNFS.DocumentDirectoryPath}/realm/timetracker`;
         this.filePath = `${this.path}/${this.filename}.realm`;
-
-        this._checkFolderCreation()
     }
 
     async save(event) {
         try {
             if(!this.filename) throw new EventTrackerError('database filename was not specified')
+
+            await this._checkFolderCreation();
             const db = await Realm.open({
                 path: this.filePath,
                 schema:[EventSchema]
@@ -38,6 +38,8 @@ class Database {
     async search(filters = '', ...values) {
         try {
             if(!this.filename) throw new EventTrackerError('database filename was not specified')
+
+            await this._checkFolderCreation();
             const db = await Realm.open({
                 path: this.filePath,
                 schema:[EventSchema]
@@ -61,6 +63,7 @@ class Database {
             if(!this.filename) throw new EventTrackerError('database filename was not specified')  
             if(!filters || !values) return null;
 
+            await this._checkFolderCreation();
             const db = await Realm.open({
                 path: this.filePath,
                 schema:[EventSchema]
@@ -83,6 +86,8 @@ class Database {
     async deleteAll() {
         try {
             if(!this.filename) throw new EventTrackerError('database filename was not specified')  
+            
+            await this._checkFolderCreation();
             const db = await Realm.open({
                 path: this.filePath,
                 schema:[EventSchema]
@@ -98,7 +103,7 @@ class Database {
         }
     }
 
-    async isFolderExist() {
+    async isFolderAvailable() {
         try {
             const folderPath = this.path;
             return await RNFS.exists(folderPath)
@@ -109,12 +114,14 @@ class Database {
 
     async removeDatabaseFolder() {
         try {
-            const folderExist = await this.isFolderExist();
+            const folderExist = await this.isFolderAvailable();
 
             if(!folderExist) return null;
             const folderPath = this.path;
 
-            return await RNFS.unlink(folderPath);
+            await RNFS.unlink(folderPath)
+            
+            return true;
         } catch (error) {
             const customError = new EventTrackerError(error);
 
@@ -134,7 +141,7 @@ class Database {
     }
     
     async _checkFolderCreation() {
-        const folderExist = await this.isFolderExist();
+        const folderExist = await this.isFolderAvailable();
         if(folderExist) {
             return null;
         }

--- a/lib/database.js
+++ b/lib/database.js
@@ -10,7 +10,7 @@ class Database {
         this.path = `${RNFS.DocumentDirectoryPath}/realm/timetracker`;
         this.filePath = `${this.path}/${this.filename}.realm`;
 
-        this._validateFolderCreation()
+        this._checkFolderCreation()
     }
 
     async save(event) {
@@ -98,14 +98,49 @@ class Database {
         }
     }
 
-    async _validateFolderCreation() {
-        const folderPath = this.path;
-        const folderExists = await RNFS.exists(folderPath)
-        if(folderExists) {
+    async isFolderExist() {
+        try {
+            // const folderPath = `${RNFS.DocumentDirectoryPath}/realm/timetracker`
+            const folderPath = this.path;
+            return await RNFS.exists(folderPath)
+        } catch(error) {
+            return false;
+        }
+    }
+
+    async removeDatabaseFolder() {
+        try {
+            const folderExist = await this.isFolderExist();
+
+            if(!folderExist) return null;
+            const folderPath = this.path;
+
+            return await RNFS.unlink(folderPath);
+        } catch (error) {
+            const customError = new EventTrackerError(error);
+
+            return Promise.reject(customError);
+        }
+    }
+
+    async createDatabaseFolder() {
+        try {
+            const folderPath = this.path;
+            return await RNFS.mkdir(folderPath)
+        } catch (error) {
+            const customError = new EventTrackerError(error);
+
+            return Promise.reject(customError);
+        }
+    }
+    
+    async _checkFolderCreation() {
+        const folderExist = await this.isFolderExist();
+        if(folderExist) {
             return null;
         }
 
-        return await RNFS.mkdir(folderPath)
+        return await this.createDatabaseFolder()
     }
 }
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -100,7 +100,6 @@ class Database {
 
     async isFolderExist() {
         try {
-            // const folderPath = `${RNFS.DocumentDirectoryPath}/realm/timetracker`
             const folderPath = this.path;
             return await RNFS.exists(folderPath)
         } catch(error) {

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -25,18 +25,6 @@ class EventTracker{
         this.db = new Database(filename);
         this.appCurrentState = AppState.currentState;
         this._handleAppStateChange = this._handleAppStateChange.bind(this);
-        this._hasTrackingFolder = null;
-
-        this._checkFolderState();
-    }
-
-    get hasFolder() {
-        return this._hasTrackingFolder;
-    }
-
-    set hasFolder(bool) {
-        this._hasTrackingFolder = bool;
-        this._handleFolderStateChange();
     }
     /**
      * Adds an event to the database after performing validations.
@@ -426,15 +414,20 @@ class EventTracker{
      * Retrieves the `time` property of the last event matching the specified ID and type.
      *
      * @async
-     * @private
      * @param {string|number} id - The identifier used to filter events.
      * @param {string} type - The type used to filter events.
      * @returns {Promise<number|null>} Resolves with the `time` property of the last matching event, or `null` if no valid event is found.
      * @throws {Error} If an error occurs during the search process, the promise is rejected with the error.
      */
 
-    async _getIdTimeByType (id,type) {
+    async getIdTimeByType (id,type) {
         try {
+
+            await Validations.idValidation(id);
+
+            const isValidType = Validations.isValidEventType(type);
+            if(!isValidType) throw new EventTrackerError('Event type is invalid')
+            
             const filters = Helpers.getFilters({id, type});
 
             const filteredEvents = await this.db.search(filters, id, type);
@@ -452,37 +445,6 @@ class EventTracker{
     }
 
     /**
-     * Retrieves the time range (start and finish times) for a given ID.
-     *
-     * @async
-     * @param {string|number} id - The register identifier.
-     * @returns {Promise<{startTime: number|null, finishTime: number|null}>} Resolves with an object containing `startTime` and `finishTime`.
-     * If either time cannot be retrieved, the corresponding property is `null`.
-     * @throws {Error} If the ID validation fails or an unexpected error occurs, the promise is rejected with the error.
-     */
-
-    async getTimeRangeById (id) {
-        try {
-            await Validations.idValidation(id);
-
-            const [startTime, startTimeError] = await Helpers.promiseWrapper(
-                this._getIdTimeByType(id,'start')
-            );
-
-            const [finishTime, finishTimeError] = await Helpers.promiseWrapper(
-                this._getIdTimeByType(id,'finish')
-            );
-
-            return {
-                startTime: !startTimeError && !!startTime ? startTime : null,
-                finishTime: !finishTimeError && !!finishTime ? finishTime : null,
-            }
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }
-
-    /**
      * Deletes the database folder and updates the folder existence flag.
      *
      * @async
@@ -490,52 +452,13 @@ class EventTracker{
      * @throws {Error} If an error occurs during the folder removal process, the promise is rejected with the error.
      */
 
-    async wipeDatabase () {
+    async removeEventsFolder () {
         try {
             await this.db.removeDatabaseFolder();
 
-            this.hasFolder = false;
+            return true;
         } catch (error) {
             return Promise.reject(error)
-        }
-    }
-
-    /**
-     * Checks if the tracking folder exists and creates it if it does not.
-     * Updates the folder existence flag accordingly.
-     *
-     * @async
-     * @private
-     * @returns {Promise<null>} Resolves with `null` if the folder already exists or if it is successfully created.
-     * If an error occurs during folder creation, `null` is returned.
-     */
-
-    async _handleFolderStateChange() {
-        if(this._hasTrackingFolder) return null;
-        
-        try {
-            await this.db.createDatabaseFolder()
-            this.hasFolder = true;
-        } catch (error) {
-            return null;
-        }
-    }
-
-    /**
-     * Verifies the existence of the folder and updates the folder existence flag.
-     *
-     * @async
-     * @private
-     * @returns {Promise<void>} Resolves after checking the folder's existence and updating the `hasFolder` flag.
-     * If an error occurs during the check, the `hasFolder` flag is set to `false`.
-     */
-
-    /*istanbul ignore next*/
-    async _checkFolderState() {
-        try {
-            this.hasFolder = await this.db.isFolderExist();
-        } catch (error) {
-            this.hasFolder = false;
         }
     }
 }

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -156,41 +156,16 @@ class EventTracker{
         }
     }   
 
-    /**
-     *  Calculates the elapsed time between the start and finish events for a given ID.
+     /**
+     *  Calculates the elapsed time between the start and finish events.
+     *  When not receive  finish time, it calculates the difference with the current time
      * 
-     * @name getElapsedTimeById
-     * @param {string} id - The ID for which to calculate the elapsed time.
-     * @returns {Promise<{days: number, hours: number ,minutes: number, seconds: number}>} A promise that resolves to the elapsed time in milliseconds.
-     * @throws {EventTrackerError} If the ID has not been tracked, or if no start event is found.
-     * @throws {Error} If an error occurs during validation or while retrieving the events.
+     * @name getElapsedTime
+     * @param {string} startTime start time in iso string format
+     * @param {string} finishTime finish time in iso string format
+     * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated elapsed time
      */
 
-    async getElapsedTimeById (id) {
-        try {
-            await Validations.idValidation(id);
-            const events = await this.getEventsById(id);
-
-            if(!events?.length) throw new EventTrackerError('ID was not tracked');
-
-            const startEvent = events.find((e) => e.type === 'start');
-
-            if(!startEvent || !Object.keys(startEvent).length) throw new EventTrackerError('ID was not tracked')
-
-            const endEvents = events.filter((e) => e.type === 'finish');
-            const lastEndEvent = Helpers.reverseArray(endEvents)[0]
-
-            const startTime = startEvent.time;
-            const currentTime = !!lastEndEvent?.time ?  lastEndEvent.time : new Date().toISOString();
-
-            const elapsedTime = Helpers.getTimeDifference(startTime, currentTime);
-
-            return elapsedTime;
-
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }
 
     getElapsedTime (startTime, finishTime) {
         
@@ -447,6 +422,17 @@ class EventTracker{
         return Validations.validateEventsSequence(type, previousType);
     }
 
+    /**
+     * Retrieves the `time` property of the last event matching the specified ID and type.
+     *
+     * @async
+     * @private
+     * @param {string|number} id - The identifier used to filter events.
+     * @param {string} type - The type used to filter events.
+     * @returns {Promise<number|null>} Resolves with the `time` property of the last matching event, or `null` if no valid event is found.
+     * @throws {Error} If an error occurs during the search process, the promise is rejected with the error.
+     */
+
     async _getIdTimeByType (id,type) {
         try {
             const filters = Helpers.getFilters({id, type});
@@ -454,8 +440,7 @@ class EventTracker{
             const filteredEvents = await this.db.search(filters, id, type);
 
             const lastIndex = filteredEvents.length - 1;
-            const lastEvent = filteredEvents[lastIndex];
-            const event = Event.parseEventFromDB(lastEvent);
+            const event = filteredEvents[lastIndex];
 
             if(!Helpers.isObject(event) || !Object.keys(event).includes('time')) return null;
 
@@ -465,6 +450,16 @@ class EventTracker{
             return Promise.reject(error);
         }
     }
+
+    /**
+     * Retrieves the time range (start and finish times) for a given ID.
+     *
+     * @async
+     * @param {string|number} id - The register identifier.
+     * @returns {Promise<{startTime: number|null, finishTime: number|null}>} Resolves with an object containing `startTime` and `finishTime`.
+     * If either time cannot be retrieved, the corresponding property is `null`.
+     * @throws {Error} If the ID validation fails or an unexpected error occurs, the promise is rejected with the error.
+     */
 
     async getTimeRangeById (id) {
         try {
@@ -479,13 +474,21 @@ class EventTracker{
             );
 
             return {
-                startTime: !startTimeError ? startTime : null,
-                finishTime: !finishTimeError ? finishTime : null,
+                startTime: !startTimeError && !!startTime ? startTime : null,
+                finishTime: !finishTimeError && !!finishTime ? finishTime : null,
             }
         } catch (error) {
             return Promise.reject(error);
         }
     }
+
+    /**
+     * Deletes the database folder and updates the folder existence flag.
+     *
+     * @async
+     * @returns {Promise<void>} Resolves when the database folder is successfully removed.
+     * @throws {Error} If an error occurs during the folder removal process, the promise is rejected with the error.
+     */
 
     async wipeDatabase () {
         try {
@@ -496,6 +499,16 @@ class EventTracker{
             return Promise.reject(error)
         }
     }
+
+    /**
+     * Checks if the tracking folder exists and creates it if it does not.
+     * Updates the folder existence flag accordingly.
+     *
+     * @async
+     * @private
+     * @returns {Promise<null>} Resolves with `null` if the folder already exists or if it is successfully created.
+     * If an error occurs during folder creation, `null` is returned.
+     */
 
     async _handleFolderStateChange() {
         if(this._hasTrackingFolder) return null;
@@ -508,6 +521,16 @@ class EventTracker{
         }
     }
 
+    /**
+     * Verifies the existence of the folder and updates the folder existence flag.
+     *
+     * @async
+     * @private
+     * @returns {Promise<void>} Resolves after checking the folder's existence and updating the `hasFolder` flag.
+     * If an error occurs during the check, the `hasFolder` flag is set to `false`.
+     */
+
+    /*istanbul ignore next*/
     async _checkFolderState() {
         try {
             this.hasFolder = await this.db.isFolderExist();

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -180,6 +180,20 @@ class EventTracker{
         }
     }
 
+    getElapsedTime (startTime, finishTime) {
+        
+        if(!startTime || !Helpers.isString(startTime)) return {
+            days:0,
+            hours: 0,
+            minutes: 0,
+            seconds: 0,
+        }
+
+        const lastTime = Validations.isString(finishTime) ? finishTime : new Date().toISOString();
+
+        return Helpers.getTimeDifference(startTime, lastTime);
+    }
+
     /**
      * Checks if an event with the given ID has already started.
      * 
@@ -419,6 +433,46 @@ class EventTracker{
         const {type:previousType} = await this.getLastEventById(id)
 
         return Validations.validateEventsSequence(type, previousType);
+    }
+
+    async _getIdTimeByType (id,type) {
+        try {
+            const filters = Helpers.getFilters({id, type});
+
+            const filteredEvents = await this.db.search(filters, id, type);
+
+            const lastIndex = filteredEvents.length - 1;
+            const lastEvent = filteredEvents[lastIndex];
+            const event = Event.parseEventFromDB(lastEvent);
+
+            if(!Helpers.isObject(event) || !Object.keys(event).includes('time')) return null;
+
+            return event.time;
+
+        } catch (error) {
+            return Promise.reject(error);
+        }
+    }
+
+    async getTimeRangeById (id) {
+        try {
+            await Validations.idValidation(id);
+
+            const [startTime, startTimeError] = await Helpers.promiseWrapper(
+                this._getIdTimeByType(id,'start')
+            );
+
+            const [finishTime, finishTimeError] = await Helpers.promiseWrapper(
+                this._getIdTimeByType(id,'finish')
+            );
+
+            return {
+                startTime: !startTimeError ? startTime : null,
+                finishTime: !finishTimeError ? finishTime : null,
+            }
+        } catch (error) {
+            return Promise.reject(error);
+        }
     }
 }
 

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -25,6 +25,18 @@ class EventTracker{
         this.db = new Database(filename);
         this.appCurrentState = AppState.currentState;
         this._handleAppStateChange = this._handleAppStateChange.bind(this);
+        this._hasTrackingFolder = null;
+
+        this._checkFolderState();
+    }
+
+    get hasFolder() {
+        return this._hasTrackingFolder;
+    }
+
+    set hasFolder(bool) {
+        this._hasTrackingFolder = bool;
+        this._handleFolderStateChange();
     }
     /**
      * Adds an event to the database after performing validations.
@@ -182,14 +194,14 @@ class EventTracker{
 
     getElapsedTime (startTime, finishTime) {
         
-        if(!startTime || !Helpers.isString(startTime)) return {
+        if(!startTime) return {
             days:0,
             hours: 0,
             minutes: 0,
             seconds: 0,
         }
 
-        const lastTime = Validations.isString(finishTime) ? finishTime : new Date().toISOString();
+        const lastTime = !!finishTime ? finishTime : new Date().toISOString();
 
         return Helpers.getTimeDifference(startTime, lastTime);
     }
@@ -472,6 +484,35 @@ class EventTracker{
             }
         } catch (error) {
             return Promise.reject(error);
+        }
+    }
+
+    async wipeDatabase () {
+        try {
+            await this.db.removeDatabaseFolder();
+
+            this.hasFolder = false;
+        } catch (error) {
+            return Promise.reject(error)
+        }
+    }
+
+    async _handleFolderStateChange() {
+        if(this._hasTrackingFolder) return null;
+        
+        try {
+            await this.db.createDatabaseFolder()
+            this.hasFolder = true;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    async _checkFolderState() {
+        try {
+            this.hasFolder = await this.db.isFolderExist();
+        } catch (error) {
+            this.hasFolder = false;
         }
     }
 }

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -45,25 +45,24 @@ import {isSameDay, differenceInMilliseconds} from 'date-fns';
         return formatDifference;
     }
 
+    static _mappedFilters(filters) {
+        if(!filters?.length || !this.isArray(filters)) return [];
+        
+        return filters.map((filter,index) => `${filter}${index}`) 
+    }
+
     static getFilters(values) {
         const {id, type} = values;
         const validID = id && this.isString(id);
         const validType = type && this.isString(type);
-        let filters = '';
+        let filters = [
+            (validID && 'id LIKE[c] $'),
+            (validType && 'type = $')
+        ].filter(Boolean);
 
-        if(validID) {
-            filters = filters.concat("id LIKE[c] $0")
-        }
+        filters = this._mappedFilters(filters)
 
-        if(validID && validType) {
-            filters = filters.concat(" && type = $1")
-        }
-
-        if(!validID && validType) {
-            filters = filters.concat("type = $0")
-        }
-
-        return filters;
+        return filters.join(' && ')
     }
 
     static promiseWrapper(promise) {


### PR DESCRIPTION
LINK DE TICKET: https://janiscommerce.atlassian.net/browse/APPSRN-343

LINK DE SUBTAREA: https://janiscommerce.atlassian.net/browse/APPSRN-344

DESCRIPCIÓN DEL REQUERIMIENTO:

CONTEXTO:

Actualmente, el método encargado de obtener el tiempo transcurrido entre 2 fechas es el método getElapsedTimeById, el cual se encarga de:
- validar el id recibido.
- obtener los eventos asociados al id.
- validar que haya eventos asociados al id.
- obtener el evento de start.validar que exista y sea valido.buscar todos los eventos de finish y obtener el último finalizado.validar que finish sea un objeto valido.hacer el calculo de tiempo entre la hora de inicio y la hora de finalización.

Varias de estas acciones exceden las responsabilidades que debería tener este método y su funcionalidad, por lo que se deben eliminar las innecesarias para quedarse únicamente con lo más relevante.

NECESIDAD:

Se plantea cambiar el funcionamiento del método para que, de todas las acciones mencionadas, sólo persistan las siguientes responsabilidades:

- validar que los datos recibidos como hora de inicio y hora de finalización sean registros correctos.
- En caso de que la hora de fin no sea un registro valido, se debe usar la hora actual.  
- hacer el calculo de tiempo entre la hora de inicio y la hora de fin.
- devolver la diferencia de tiempo entre ambos valores.

DESCRIPCIÓN DE LA SOLUCIÓN:

Se rehizo el método getElapsedTImeById y se le cambió el nombre a getElapsedTime. Ahora, este método recibe 2 valores, el tiempo de inicio y el tiempo de finalización, y resume su funcionalidad en calclular y devolver la diferencia en el mismo formato que la función previa:

```js
{
 days: 1,
 hours:0,
 minutes: 30,
 seconds: 15
}
```

También se agregaron nuevos métodos privados y publicos:
los publicos son:
- `getElapsedTime`
- `getTImeRangeById` que devuelve un objeto con el startTime y finishTime que están asociados al id recibido como argumento.
- `wipeDatabase` que elimina la base de datos.

los privados:
- `getIdTimeByType`, método que utiliza getTimeRange... para obtener los tiempos de inicio y fin de un id, este método trae los registros asociados en base a un id y tipo, que son los que usa para filtrar los registros de la base de datos.
- `_checkFolderCreation`, metodo que valida si ya hay una carpeta dónde almacenar los registros de tiempo.
- `_handleFolderStateChange`, método que se usa en un setter de la clase para ejecutarse cuando se produce un cambio en la propiedad privada `_hasTrackingFolder`, y que, en caso de que su valor sea `false` ejecutará el método `createDatabaseFolder`de la clase database para crear una nueva carpeta en dónde almacenar los registros de tiempo.

Además, se agregaron nuevos métodos en la clase Database que se encargar de eliminar y crear la base de datos, así como también validar que esta se encuentre creada.

Se hicieron ajustes en los métodos de la clase Helpers para facilitar su lectura y que puedan escalar a futuro.

¿CÓMO PROBARLO? 

Para probarlo se debe vincular el package al repositorio y generar una nueva instancia de EventTracker.
En caso de no haberlo hecho:

```js
import EventTrackerClass from '@janiscommerce/app-tracking-time';
import {ENV} from 'env.json';

const EventTracker = new EventTrackerClass('event-tracker');

export default EventTracker;
```

Una vez hecho esto ya podrá agregar nuevos eventos llamando al método `addEvent` (async).

Se puede usar esta botonera:

```js
 import EventTracker from 'src/utils/eventTracker';
  import Button from 'src/components/Button';
  import { promiseWrapper } from '@janiscommerce/apps-helpers';

       const addEvent = async (id, type,time, payload) => {
		const [response, error] = await promiseWrapper(EventTracker.addEvent({id,type,time,payload}))

		console.log('error', error)
		console.log('time', response)
	}

	const getCurrentTime = async (id) => {
		const [times, error] = await promiseWrapper(EventTracker.getTimeRangeById(id))
                const {startTime = '', finishTime = ''} = times || {}
               
                const elaspedTime = EventTracker.getElapsedTime(startTIme, finishTime)
		
               console.log('elaspedTime', elaspedTime)
	}

  <>
    	<Button title={'agregar primer id'} onPress={() => addEvent('123-session','start')}/>
	<Button title={'agregar segundo id'} onPress={() => addEvent('234-session','start')}/>
	<Button title={'agregar tercer id'} onPress={() => addEvent('345-session','start')}/>
	<Button title={'pausar primer id'} onPress={() => addEvent('123-session','pause')}/>
	<Button title={'pausar segundo id'} onPress={() => addEvent('234-session','pause')}/>
        <Button title={'pausar tercer id'} onPress={() => addEvent('345-session','pause')}/>
	<Button title={'continuar primer id'} onPress={() => addEvent('123-session','resume')}/>
	<Button title={'continuar segundo id'} onPress={() => addEvent('234-session','resume')}/>
        <Button title={'continuar tercer id'} onPress={() => addEvent('345-session','resume')}/>
	<Button title={'finalizar primer id'} onPress={() => addEvent('123-session','finish')}/>
	<Button title={'finalizar segundo id'} onPress={() => addEvent('234-session','finish')}/>
        <Button title={'finalizar tercer id'} onPress={() => addEvent('345-session','finish')}/>
	<Button title={'tiempo transcurrido primer id'} onPress={() => getCurrentTime('123-session')}/>
	<Button title={'tiempo transcurrido segundo id'} onPress={() => getCurrentTime('234-session')}/>
        <Button title={'tiempo transcurrido tercer id'} onPress={() => getCurrentTime('345-session')}/>
  </>
```

Cuando presione el botón de tiempo transcurrido debería devolverle la diferencia formateada si es que inició el trackeo. Si no lo finalizó este valor cambiará debido a que hará el calculo contra la hora actual.

Para probar el borrado de la base de datos debería usar el método `wipeDatabase` en dónde quiera y luego chequear que no haya registros asociados a un id o que la base de datos se encuentre vacía

```js
const [succesfully, errorResp] = await promiseWrapper(EventTracker.wipeDatabase())

console.log('succesfully', succesfully)
console.log('errorResp', errorResp)
```

Tenga en cuenta que este método elimina la base de datos, pero, por cómo se programó el funcionamiento de la clase, así como la elimina se generará una nueva carpeta para almacenar la base de datos.