### PR TITLE
getIdTimeByType validation was fixed

### DIFF
--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -434,10 +434,11 @@ class EventTracker{
 
             const lastIndex = filteredEvents.length - 1;
             const event = filteredEvents[lastIndex];
+            const parsedEvent = Event.parseEventFromDB(event);
 
-            if(!Helpers.isObject(event) || !Object.keys(event).includes('time')) return null;
+            if(!Helpers.isObject(parsedEvent) || !parsedEvent["time"]) return null;
 
-            return event.time;
+            return parsedEvent["time"];
 
         } catch (error) {
             return Promise.reject(error);

--- a/lib/event.js
+++ b/lib/event.js
@@ -16,7 +16,7 @@ class Event {
     }
 
     static parseEventForDB(event) {
-        const {id, type, time, payload} = event;
+        const {id, type, time, payload} = event || {};
         let parsedPayload;
 
         try {


### PR DESCRIPTION
CONTEXTO

Cuando continué los ajustes sobre el componente sessionTimer en picking me di cuenta que el método `getIdTimeByType` siempre devolvía null, y revisandólo encontré que esto era porque, al obtener el evento desde la base de datos y no parsearlo, no superaba la validación de tener la key "time", por lo que siempre entraba en la condición del if y forzaba a que se devuelva `true`.

SOLUCIÓN:

Se cambió la validación para que, ahora, sólo devuelva null en caso de que el valor que se obtenga de la DB NO SEA un objeto, o que no contenga un valor en la key "time".