### PR TITLE
added method to control app focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,32 @@ The package has internal validations that prevent events from being saved consec
 For example, you will not be able to store 2 pause type events consecutively. Additionally, saving any event related to an ID that has already been finished is also not allowed.
 
 If you want to know what was the last event that was stored for a particular id, you can call the getLastEventById method, which will return an object with the information of the last stored event, including the type.
+
+### My recording stops when I open the camera or request permissions
+
+The package is programmed to take care of stopping all possible tracking when the application goes into the background. However, this on android has some problems:
+
+Because of the way react-native's AppState API works, the package interprets the app as being in the background whenever the camera is used or the user is asked for permission.
+This happens because, in Android, it is interpreted that the intervention of another application (camera, permissions manager) is considered a process that runs in front of our application, so it would be in the background
+To solve this problem (partially) you can indicate, using the setFocus method of eventTracker, that the application is in the foreground, even when these processes are running, which will prevent erroneous pause events from being logged
+
+```js
+
+const handleCameraOpen = () => {
+    eventTracker.setFocus = true;
+    setCameraVisible(true):
+}
+
+```
+
+However, you will need to remember to set the focus to false when closing the activity so that the app can continue recording pauses when the user leaves the app in the background
+
+
+```js
+
+const handleCameraClose = () => {
+    setCameraVisible(false):
+    eventTracker.setFocus = false;
+}
+
+```

--- a/__test__/eventTracker.test.js
+++ b/__test__/eventTracker.test.js
@@ -389,4 +389,28 @@ describe('EventTracker class', () => {
             })
          })
     })
+
+    describe('isFocused getter and setFocused setter', () => { 
+        it('should return _appFocused property value', () => {
+            const state = eventTracker.isFocused;
+
+            expect(typeof state).toStrictEqual('boolean')
+
+
+        })
+
+        it('should set new _appFocused state', () => {
+            eventTracker.setFocus = true;
+            const state = eventTracker.isFocused;
+
+            expect(state).toBeTruthy();
+        }) 
+
+        it('shouldn t set new appFocused state if value isnt a boolean', () => {
+            eventTracker.setFocus = 3;
+            const state = eventTracker.isFocused;
+
+            expect(state).toBeTruthy();
+        })
+     })
  })

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -25,11 +25,11 @@ class EventTracker{
         this.db = new Database(filename);
         this.appCurrentState = AppState.currentState;
         this._handleAppStateChange = this._handleAppStateChange.bind(this);
-        this._appFocused = false;
+        this._focus = false;
     }
 
     get isFocused() {
-        return this._appFocused;
+        return this._focus;
     }
     
     /**
@@ -37,7 +37,7 @@ class EventTracker{
      */
     set setFocus(bool) {
         if(typeof bool !== 'boolean') return;
-        this._appFocused = bool;
+        this._focus = bool;
     }
     /**
      * Adds an event to the database after performing validations.

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -25,6 +25,19 @@ class EventTracker{
         this.db = new Database(filename);
         this.appCurrentState = AppState.currentState;
         this._handleAppStateChange = this._handleAppStateChange.bind(this);
+        this._appFocused = false;
+    }
+
+    get isFocused() {
+        return this._appFocused;
+    }
+    
+    /**
+     * @param {boolean} bool
+     */
+    set setFocus(bool) {
+        if(typeof bool !== 'boolean') return;
+        this._appFocused = bool;
     }
     /**
      * Adds an event to the database after performing validations.
@@ -269,8 +282,7 @@ class EventTracker{
     /*istanbul ignore next*/
     async _handleAppStateChange(nextAppState) {
         try {
-            if (this.appCurrentState.match(/active|foreground/) && nextAppState === 'background') {
-
+            if (this.appCurrentState.match(/active|foreground/) && nextAppState === 'background' && !this.isFocused) {
               await this._stopEventsInBackground();
             }
             this.appCurrentState = nextAppState;


### PR DESCRIPTION
CONTEXTO

Haciendo pruebas en la app de picking encontramos que, cada vez que se abría la cámara, el pkg interpretaba que la aplicación pasaba a segundo plano debido al funcionamiento de la api appState de react-native, api que utilizamos para reconocer el cambio de estado de la aplicación y guardar eventos de pausa para todos los registros posibles de manera automatica.

Sin embargo, en este caso el comportamiento es erroneo, ya que la app no está en segundo plano, sino que se encuentra activa pero, a interpretación de RN, por detrás de otro proceso/actividad.

SOLUCIÓN

Para resolver este problema, al menos momentaneamente, lo que hicimos fue agregar una variable privada `_focused` dentro del pkg que indica que la app está enfocada, 
Esta variable puede ser modificado mediante el setter `setFocus`, que modifica el valor de esa variable.

Para evitar que el pkg haga la pausa automatica modificamos la condicional encargada de ejecutar ese bloque de código para que, además de la comprobaciones que ya hace, la condición que también se debe cumplir para la pausa automatica es que la prop  `_focused` tenga un valor `false`. De esta manera evitamos que se produzcan los registros involuntarios.