### PR TITLE
Added methods to calculate stop time and net time

### DIFF
--- a/__test__/eventTracker.test.js
+++ b/__test__/eventTracker.test.js
@@ -153,25 +153,10 @@ describe('EventTracker class', () => {
         })
         
         describe('should return stopped time', () => {
-          it('after adding up all the milliseconds between pauses and resumes', () => {
-            const registeredEvents = [
-                {id:'345',type:'start'},
-                {id:'345',type:'pause',time:'2023-01-01T00:00:10.000Z'},
-                {id:'345',type:'resume', time:'2023-01-01T00:00:20.000Z'},
-                {id:'345',type:'pause',time:'2023-01-01T00:00:40.000Z'},
-                {id:'345',type:'pause',time:'2023-01-01T00:01:00.000Z'},
-                {id:'345',type:'resume', time:'2023-01-01T00:01:20.000Z'},
-                {id:'345',type:'pause',time:'2023-01-01T00:01:40.000Z'},
-            ]
-
-            const response = eventTracker.getStoppedTime({events:registeredEvents});
-
-            expect(response).toStrictEqual(30000)
-          })
 
           it('should return stopped time in time format if format params is true', () => {
             const registeredEvents = [
-                {id:'345',type:'start'},
+                {id:'345',type:'pause',time:'2023-01-01T00:00:10.000Z'},
                 {id:'345',type:'pause',time:'2023-01-01T00:00:10.000Z'},
                 {id:'345',type:'resume', time:'2023-01-01T00:00:20.000Z'},
                 {id:'345',type:'pause',time:'2023-01-01T00:00:40.000Z'},

--- a/__test__/eventTracker.test.js
+++ b/__test__/eventTracker.test.js
@@ -123,7 +123,11 @@ describe('EventTracker class', () => {
 
         describe('return default elapsedTime', () => { 
             it('should return default elapsedTime when startTime is null', () => {
-                expect(eventTracker.getElapsedTime()).toStrictEqual(DEFAULT_ELAPSED_TIME)
+                expect(eventTracker.getElapsedTime({})).toStrictEqual(DEFAULT_ELAPSED_TIME)
+            })
+
+            it('should return 0 when startTime is null and formatted is false', () => {
+                expect(eventTracker.getElapsedTime({formatted:false})).toStrictEqual(0)
             })
          })
 
@@ -139,7 +143,7 @@ describe('EventTracker class', () => {
                     seconds:0
                 })
 
-                const response = eventTracker.getElapsedTime(startTime,finishTime)
+                const response = eventTracker.getElapsedTime({startTime,finishTime})
                 expect(response).toStrictEqual({
                     days:0,
                     hours:0,
@@ -152,23 +156,15 @@ describe('EventTracker class', () => {
          it('but, if the id hasnt finish time, la comparación se realizará contra la hora actual', async () => {
             jest.spyOn(mockDate, 'toISOString').mockReturnValueOnce('2023-01-01T00:15:00.000Z');
 
-            diffTimeMock.mockReturnValueOnce({
-                days:0,
-                hours:0,
-                minutes:15,
-                seconds:0
-            })
+            diffTimeMock.mockReturnValueOnce(60116031652)
 
             const startTime = '2023-01-01T00:00:00.000Z';
 
-            const response = eventTracker.getElapsedTime(startTime)
+            const response = eventTracker.getElapsedTime({startTime, formatted: false})
 
-            expect(response).toStrictEqual({
-                days:0,
-                hours:0,
-                minutes:15,
-                seconds:0
-            })
+            console.log('response', response)
+
+            expect(response).toStrictEqual(60116031652)
          })
     })
 

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -159,7 +159,7 @@ class EventTracker{
 
             if(nextEvent.type === 'pause') return time;
 
-            if(nextEvent.type !== 'resume') {
+            if(!Object.keys(nextEvent).length) {
                 nextEvent.time = new Date();
             }
 

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -4,6 +4,7 @@ import Database from './database';
 import Validations from '../utils/validations';
 import Helpers from '../utils/helpers';
 import { AppState } from 'react-native';
+import { differenceInMilliseconds } from 'date-fns';
 
 /**
  * Manages events, including adding, retrieving, and validating them.
@@ -54,43 +55,6 @@ class EventTracker{
             return {
                 id,
                 time: createdEvent.time,
-            }
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }
-
-    /**
-     * @name addManyEvents
-     * @description This method allows create the same event for multiple IDs.
-     * @param {string[]} ids 
-     * @param {string} type 
-     * @returns {Promise<{createdEvents: {id: string, time: string}[], errors: {id: string, error: string}[]}>}
-     */
-
-    async addManyEvents(ids, type) {
-        try {
-            if(!ids || !Helpers.isArray(ids)) throw new EventTrackerError(`an array of ids was expected`)
-
-            let createdEvents = [];
-            let errors = [];
-
-            for(const id of ids) {
-                const [savedEvent, error] = await Helpers.promiseWrapper(
-                    this.addEvent({id,type})
-                )
-
-                if(error) {
-                    errors.push({id, error: error?.message})
-                    continue;
-                }
-
-                createdEvents.push(savedEvent)
-            }
-
-            return {
-                createdEvents,
-                errors
             }
         } catch (error) {
             return Promise.reject(error);
@@ -149,10 +113,10 @@ class EventTracker{
      *  When not receive  finish time, it calculates the difference with the current time
      * 
      * @name getElapsedTime
-     * @param {{startTime, finishTime, formatted}} param
+     * @param {{startTime, finishTime, format}} param
      * @param {string} startTime start time in iso string format
      * @param {string} finishTime finish time in iso string format
-     * @param {boolean} formatted if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
+     * @param {boolean} format if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
      * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated elapsed time
      */
 
@@ -160,10 +124,10 @@ class EventTracker{
     getElapsedTime ({
         startTime,
         finishTime, 
-        formatted = true
+        format = true
         }) {
         
-        if(!startTime) return formatted ? {
+        if(!startTime) return format ? {
             days:0,
             hours: 0,
             minutes: 0,
@@ -172,7 +136,68 @@ class EventTracker{
 
         const lastTime = !!finishTime ? finishTime : new Date().toISOString();
 
-        return Helpers.getTimeDifference(startTime, lastTime, formatted);
+        return Helpers.getTimeDifference(startTime, lastTime, format);
+    }
+
+    /**
+     *  Calculates the time elapsed between each pause and resume of an id.
+     * 
+     * @name getStoppedTime
+     * @param {{id: string, time: string, payload: object, type: string}[]} events events associated with an id
+     * @param {boolean} format if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
+     * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated stopped time
+    */
+
+    getStoppedTime ({events = [], format = false}) {
+        if(!events?.length || !Helpers.isArray(events)) return 0;
+
+        const stoppedTime = events.reduce((time, currentEvent, index) => {
+            if(currentEvent.type !== 'pause') return time;
+
+            const nextEvent = events[index + 1] || {};
+            if(nextEvent.type !== 'resume') return time;
+
+            const pauseEvent = new Date(currentEvent.time);
+            const resumeEvent = new Date(nextEvent.time);
+
+            const timeDifference = differenceInMilliseconds(resumeEvent, pauseEvent);
+            time = time + timeDifference;
+            return time;
+        }, 0)
+
+        if(format) return Helpers.convertMillisecondsToTime(stoppedTime);
+        
+        return stoppedTime;
+    }
+
+    /**
+     * Calculates the net time between start and finish, discounting pauses
+     * 
+     * @name getNetTrackingTime
+     * @param {string} events tracked events 
+     * @param {boolean} format if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
+     * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated net time
+    */
+
+    getNetTrackingTime ({events = [], format = false}) {
+        if(!events?.length || !Helpers.isArray(events)) return 0;
+    
+        const startEvent = Helpers.findEventByStatus(events,'start');
+        const finishEvent = Helpers.findEventByStatus(events, 'finish');
+        const elapsedTime = this.getElapsedTime({
+            startTime: startEvent?.time,
+            finishTime: finishEvent?.time,
+            format: false,
+        })
+
+        if(!elapsedTime || elapsedTime <= 0) return 0;
+
+        const stoppedTime = this.getStoppedTime({events});
+        const netTime = elapsedTime - stoppedTime;
+
+        if(format) return Helpers.convertMillisecondsToTime(netTime);
+
+        return netTime;
     }
 
     /**

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -165,14 +165,14 @@ class EventTracker{
     getStoppedTime ({events = [], format = false}) {
         if(!events?.length || !Helpers.isArray(events)) return 0;
 
-        const stoppedTime = events.reduce((time, currentEvent, index) => {
-            if(currentEvent.type !== 'pause') return time;
+        const stoppedTime = events.reduce((totalPausedTime, currentEvent, index) => {
+            if(currentEvent.type !== 'pause') return totalPausedTime;
 
             let nextEvent = events[index + 1] || {};
 
-            if(nextEvent.type === 'pause') return time;
+            if(nextEvent.type === 'pause') return totalPausedTime;
 
-            if(!Object.keys(nextEvent).length) {
+            if(nextEvent.type !== 'resume' && nextEvent.type !== 'finish') {
                 nextEvent.time = new Date();
             }
 
@@ -180,8 +180,7 @@ class EventTracker{
             const pauseTime = new Date(currentEvent.time);
             const timeDifference = differenceInMilliseconds(resumeTime, pauseTime);
 
-            time = time + timeDifference;
-            return time;
+            return totalPausedTime + timeDifference;
         }, 0)
 
         if(format) return Helpers.convertMillisecondsToTime(stoppedTime);

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -149,24 +149,30 @@ class EventTracker{
      *  When not receive  finish time, it calculates the difference with the current time
      * 
      * @name getElapsedTime
+     * @param {{startTime, finishTime, formatted}} param
      * @param {string} startTime start time in iso string format
      * @param {string} finishTime finish time in iso string format
+     * @param {boolean} formatted if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
      * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated elapsed time
      */
 
 
-    getElapsedTime (startTime, finishTime) {
+    getElapsedTime ({
+        startTime,
+        finishTime, 
+        formatted = true
+        }) {
         
-        if(!startTime) return {
+        if(!startTime) return formatted ? {
             days:0,
             hours: 0,
             minutes: 0,
             seconds: 0,
-        }
+        } : 0;
 
         const lastTime = !!finishTime ? finishTime : new Date().toISOString();
 
-        return Helpers.getTimeDifference(startTime, lastTime);
+        return Helpers.getTimeDifference(startTime, lastTime, formatted);
     }
 
     /**

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -148,19 +148,25 @@ class EventTracker{
      * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated stopped time
     */
 
+    //istanbul ignore next
     getStoppedTime ({events = [], format = false}) {
         if(!events?.length || !Helpers.isArray(events)) return 0;
 
         const stoppedTime = events.reduce((time, currentEvent, index) => {
             if(currentEvent.type !== 'pause') return time;
 
-            const nextEvent = events[index + 1] || {};
-            if(nextEvent.type !== 'resume') return time;
+            let nextEvent = events[index + 1] || {};
 
-            const pauseEvent = new Date(currentEvent.time);
-            const resumeEvent = new Date(nextEvent.time);
+            if(nextEvent.type === 'pause') return time;
 
-            const timeDifference = differenceInMilliseconds(resumeEvent, pauseEvent);
+            if(nextEvent.type !== 'resume') {
+                nextEvent.time = new Date();
+            }
+
+            const resumeTime = new Date(nextEvent.time);
+            const pauseTime = new Date(currentEvent.time);
+            const timeDifference = differenceInMilliseconds(resumeTime, pauseTime);
+
             time = time + timeDifference;
             return time;
         }, 0)

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,5 +1,12 @@
 import {isSameDay, differenceInMilliseconds} from 'date-fns';
 
+const DEFAULT_TIME_VALUES = {
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0
+}
+
  class Helpers {
     static isString(str) {
         return !!(typeof str === 'string') && !!str.length;
@@ -21,30 +28,41 @@ import {isSameDay, differenceInMilliseconds} from 'date-fns';
         return arr.slice().reverse()
     }
 
-    static getTimeDifference (start, end, formatted) {
+    static getTimeDifference (start, end, format) {
         const parsedStart = new Date(start);
         const parsedEnd = new Date(end);
         const sameDay = isSameDay(parsedStart, parsedEnd);
         const miliseconds = differenceInMilliseconds(parsedEnd, parsedStart);
+
+        if(!format) return miliseconds;
+
+        const {days, hours, minutes, seconds} = this.convertMillisecondsToTime(miliseconds)
+
+        return {
+            days: sameDay ? 0 : days,
+            hours,
+            minutes,
+            seconds
+        }
+    }
+
+    static convertMillisecondsToTime (miliseconds) {
+        if(!miliseconds) return DEFAULT_TIME_VALUES;
+
         const seconds = Math.floor(miliseconds / 1000);
         const hours = Math.floor(seconds / 3600);
-
-        if(!formatted) return miliseconds;
-        
-        const days = sameDay ? 0 : Math.floor(hours / 24);
+        const days = Math.floor(hours / 24);
         const minutes = Math.floor((seconds % 3600) / 60);
         const restSeconds = seconds % 60;
         const restHours = hours % 24;
 
 
-        const formatDifference = {
+        return {
             days,
             hours: restHours,
             minutes,
             seconds: restSeconds
-        }
-
-        return formatDifference;
+        } 
     }
 
     static _mappedFilters(filters) {

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -21,13 +21,15 @@ import {isSameDay, differenceInMilliseconds} from 'date-fns';
         return arr.slice().reverse()
     }
 
-    static getTimeDifference (start, end) {
+    static getTimeDifference (start, end, formatted) {
         const parsedStart = new Date(start);
         const parsedEnd = new Date(end);
         const sameDay = isSameDay(parsedStart, parsedEnd);
         const miliseconds = differenceInMilliseconds(parsedEnd, parsedStart);
         const seconds = Math.floor(miliseconds / 1000);
         const hours = Math.floor(seconds / 3600);
+
+        if(!formatted) return miliseconds;
         
         const days = sameDay ? 0 : Math.floor(hours / 24);
         const minutes = Math.floor((seconds % 3600) / 60);


### PR DESCRIPTION
## LINK DE TAREA:
https://janiscommerce.atlassian.net/browse/APPSRN-363

## LINK DE SUBTAREA:
https://janiscommerce.atlassian.net/browse/APPSRN-364

### CONTEXTO

Actualmente, con el método getElapsedTImede la clase EventTracker estamos obteniendo el tiempo transcurrido entre la hora de inicio y la hora de finalización de seguimiento de un id, o entre la hora de inicio y la hora actual en caso de que este registro siga en curso.

Sin embargo, esto tiene 2 problemas:
- El primero es que el método mencionado nos devuelve el tiempo ya formateado en formato dias:horas:minutos:segundos, lo que no nos permite manipular esta diferencia de otra manera que la recibida desde el package. Para cambiar esto, lo que se propuso fue agregar un nuevo parámetro al método getElapsedTIme:
- El parametro format definirá si el tiempo transcurrido entre 2 fechas debe ser devuelto formateado o en milisegundos. Esto nos permitirá trabajar con el dato que más nos convenga según la situación::
  - Por default, este valor empezará en true, lo que significa que, a menos que en la implementación definamos que su valor sea false, el método siempre devolverá el tiempo transcurrido formateado.
  - El segundo es que este método no contempla los registros  de tipo pause y resume asociados al id, lo que devuelve un tiempo absoluto sin descontarle el tiempo transcurrido entre pausas de seguimiento de un id.

### NECESIDAD

En base a esto se propone modificar el funcionamiento de getElapsedTime para que acepte la nueva prop mencionada y también agregar un método similar que se encargue de obtener el tiempo neto entre 2 fechas, por lo que, para eso, se debe hacer el calculo del tiempo total - los tiempos de pausas.

DESCRIPCIÓN DE LA SOLUCIÓN:

Se adaptó `getElapsedTime` para que pueda recibir un objeto como argumento, y que este objeto contenga los valores:
- `startTime`, hora de inciio obligatoria
- `finishTime`, hora de finalización opcional (se toma la hora actual en caso de que no esté)
- `format`, por defecto su valor es `true`, por lo que siempre devolverá el valor formateado a menos que se declare lo contrario.

Este cambio permite que el dato obtenido sea más flexible y utilizable en varias situaciones.

Se agregaron los métodos `getStoppedTime` y `getNetTrackingTime`:
- El primero se encarga de obtener el tiempo acumulado entre los tiempos de pausa y los tiempos de resumen. 
Este método también contempla que, en caso de que no haya un evento de resumen, se acumula el tiempo desde el último evento de pausa hasta la hora actual, porque se considera que, al no haber un tiempo de resumen, significa que ese seguimiento sigue pausado.
- El segundo se encarga de obtener el tiempo neto de seguimiento, que se obtiene de tomar el tiempo total de seguimiento asociado a un ID (mediante `getElapsedTime`) restandole el tiempo de pausa (`getStoppedTime`). 

### ¿Cómo se pueden probar?

- Vincular el pkg a cualquier app y luego, en la pantalla de notificaciones, planchar este código:

```js
import React from 'react';
import t from 'src/i18n/utils/t';
import Styles from './styles';
import EventTracker from 'src/utils/eventTracker';
import Button from 'src/components/Button';
import { promiseWrapper } from '@janiscommerce/apps-helpers';

const Notifications = () => {
	
	const addEvent = async (id, type,time, payload) => {
		const [response, error] = await promiseWrapper(EventTracker.addEvent({id,type,time,payload}))

		console.log('error', error)
		console.log('response', response)
  	}
	
	const reset = async (id) => {
		const [response, error] = await promiseWrapper(EventTracker.deleteEventsById(id))
		console.log('error', error)
		console.log('response', response)
	}

	const getElapsedTime = async (id) => {
		const [events, error] = await promiseWrapper(EventTracker.getEventsById(id));

		if(error) return console.log(error);

		const {time : startTime} = events.find((event) => event.type === 'start') || {};
		const {time: finishTime} = events.find((event) => event.type === 'finish') || {};

		const elapsedTime = EventTracker.getElapsedTime({
			startTime,
			finishTime,
			format:true
		});

		console.log('elapsedTime', elapsedTime)
	}

	const getNetTime = async (id) => {
		const [events, error] = await promiseWrapper(EventTracker.getEventsById(id));

		if(error) return console.log(error);

		const netTime = EventTracker.getNetTrackingTime({
			events,
			format: true
		});

		console.log('netTime', netTime)
	}
	return (
		<Styles.Wrapper testID="notifications">
			<>
				<Button title={'iniciar seguimiento'} onPress={() => addEvent('123456789','start')}/>
				<Button title={'pausar seguimiento'} onPress={() => addEvent('123456789','pause')}/>
				<Button title={'continuar seguimiento'} onPress={() => addEvent('123456789','resume')}/>
				<Button title={'finalizar seguimiento'} onPress={() => addEvent('123456789','finish')}/>
				<Button title={'reiniciar seguimeinto'} onPress={() => reset('123456789')}/>
				<Button title={'obtener tiempo de seguimiento total'} onPress={() => getElapsedTime('123456789')}/>
				<Button title={'obtener tiempo de seguimiento NETO'} onPress={() => getNetTime('123456789')}/>
			</>
		</Styles.Wrapper>
	)
};
```

Para probar el funcionamiento hay que jugar con la botonera. Todos los botones están asociados al id `123456789`, por lo que, para ver cómo funcionan hay que iniciar el seguimiento con el botón correspondiente, e ir pausandolo y resumiendolo.
Luego de un par de eventos se puede apretar el botón de obtener tiempos de seguimiento, tanto el total como el neto.

