### PR TITLE
Automatic background tracking has been removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,24 +95,6 @@ const deleteEvents = async (id) => {
 <Button title='remove events' onPress={() => deleteEvents('66e99577e128deb19d57cd74')}/>
 ```
 
-### Pause all tracked ids when the app goes into the background.
-
-To save a pause event for all followed ids, you can use startListening and stopListening methods.
-
-These methods are listeners that are responsible for detecting the change of state of the application. When the app enters the background, they execute a massive action that is responsible for stopping the tracking of all the IDs that are registered up to that moment in the database.
-
-The best way to use it would be to call a useEffect hook on some component that, if possible, is not unmounted until the application goes into the background or is closed.
-
-```js
-useEffect(() => {
-    EventTracker.startListening();
-
-    return () => {
-        EventTracker.stopListening();
-    }
-},[])
-```
-
 The cleanup method will be called once the component is unmounted and will unlisten for state changes from the app.
 If any of the events you want to pause is already paused, what will happen is that the console will throw a warning with the error reported by the package.
 
@@ -122,32 +104,3 @@ The package has internal validations that prevent events from being saved consec
 For example, you will not be able to store 2 pause type events consecutively. Additionally, saving any event related to an ID that has already been finished is also not allowed.
 
 If you want to know what was the last event that was stored for a particular id, you can call the getLastEventById method, which will return an object with the information of the last stored event, including the type.
-
-### My recording stops when I open the camera or request permissions
-
-The package is programmed to take care of stopping all possible tracking when the application goes into the background. However, this on android has some problems:
-
-Because of the way react-native's AppState API works, the package interprets the app as being in the background whenever the camera is used or the user is asked for permission.
-This happens because, in Android, it is interpreted that the intervention of another application (camera, permissions manager) is considered a process that runs in front of our application, so it would be in the background
-To solve this problem (partially) you can indicate, using the setFocus method of eventTracker, that the application is in the foreground, even when these processes are running, which will prevent erroneous pause events from being logged
-
-```js
-
-const handleCameraOpen = () => {
-    eventTracker.setFocus = true;
-    setCameraVisible(true):
-}
-
-```
-
-However, you will need to remember to set the focus to false when closing the activity so that the app can continue recording pauses when the user leaves the app in the background
-
-
-```js
-
-const handleCameraClose = () => {
-    setCameraVisible(false):
-    eventTracker.setFocus = false;
-}
-
-```

--- a/__test__/eventTracker.test.js
+++ b/__test__/eventTracker.test.js
@@ -290,90 +290,6 @@ describe('EventTracker class', () => {
         })
     })
 
-    describe('stopEventsInBackground method', () => { 
-        describe('throws an error when', () => { 
-            it('database search fails', async () => {
-                searchFn.mockRejectedValueOnce('error');
-
-                const [, error] = await Helpers.promiseWrapper(
-                    eventTracker._stopEventsInBackground()
-                )
-
-                expect(error.message).toStrictEqual('error')
-            })
-         })
-
-         describe('return empty array when', () => { 
-            it('database ids were not obtained', async () => {
-                searchFn.mockResolvedValueOnce([]);
-
-                const response = await eventTracker._stopEventsInBackground();
-
-                expect(response).toStrictEqual([])
-            })
-        })
-
-        describe('return an array with paused times when', () => { 
-            it('ids are valid and this is not paused', async () => {
-                saveFn
-                    .mockResolvedValueOnce({})
-
-                searchFn
-                    .mockResolvedValueOnce([{id:'12345',type:'start'},{id:'234',type:'start'},{id:'234',type:'pause'}])
-                    .mockResolvedValueOnce([{id:'12345',type:'start'}])
-                    .mockResolvedValueOnce([{id:'12345',type:'start'}])
-                    .mockResolvedValueOnce([{id:'234',type:'start'},{id:'234',type:'pause'}])
-                
-                
-
-                const response = await eventTracker._stopEventsInBackground();
-
-                expect(response.length).toBe(1);
-            })
-
-            it('ignore elements that throws errors when try to obtain last event',  async () => {
-
-                searchFn
-                    .mockResolvedValueOnce([{id:'12345',type:'start'},{id:'234',type:'start'},{id:'234',type:'pause'}])
-                    .mockRejectedValueOnce(new Error('database error'))
-                    .mockResolvedValueOnce([{id:'234',type:'start'},{id:'234',type:'pause'}])
-                
-
-                const response = await eventTracker._stopEventsInBackground();
-
-                expect(response).toStrictEqual([])
-            })
-
-            it('ignore elements that throws errors when try to obtain last event',  async () => {
-                searchFn
-                    .mockResolvedValueOnce([{id:'12345',type:'start'},{id:'234',type:'start'},{id:'234',type:'pause'}])
-                    .mockResolvedValueOnce([{id:'12345',type:'start'}])
-                    .mockRejectedValueOnce(new Error('database error'))
-                    .mockResolvedValueOnce([{id:'234',type:'start'},{id:'234',type:'pause'}])
-                
-
-                const response = await eventTracker._stopEventsInBackground();
-
-                expect(response).toStrictEqual([])
-            })
-
-            it('ignore elements that throws errors when try to obtain last event',  async () => {
-                saveFn
-                    .mockRejectedValueOnce(new Error('invalid id'))
-                searchFn
-                    .mockResolvedValueOnce([{id:'12345',type:'start'},{id:'234',type:'start'},{id:'234',type:'pause'}])
-                    .mockResolvedValueOnce([{id:'12345',type:'start'}])
-                    .mockRejectedValueOnce(new Error('database error'))
-                    .mockResolvedValueOnce([{id:'234',type:'start'},{id:'234',type:'pause'}])
-                
-
-                const response = await eventTracker._stopEventsInBackground();
-
-                expect(response).toStrictEqual([])
-            })
-        })
-    })
-
     describe('removeFinishById method', () => { 
         it('remove finish event when delete database method resolved correctly', async () => {
             deleteFn.mockResolvedValueOnce();
@@ -439,28 +355,4 @@ describe('EventTracker class', () => {
             })
          })
     })
-
-    describe('isFocused getter and setFocused setter', () => { 
-        it('should return _appFocused property value', () => {
-            const state = eventTracker.isFocused;
-
-            expect(typeof state).toStrictEqual('boolean')
-
-
-        })
-
-        it('should set new _appFocused state', () => {
-            eventTracker.setFocus = true;
-            const state = eventTracker.isFocused;
-
-            expect(state).toBeTruthy();
-        }) 
-
-        it('shouldn t set new appFocused state if value isnt a boolean', () => {
-            eventTracker.setFocus = 3;
-            const state = eventTracker.isFocused;
-
-            expect(state).toBeTruthy();
-        })
-     })
  })

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -3,7 +3,6 @@ import EventTrackerError from './event-tracker-error';
 import Database from './database';
 import Validations from '../utils/validations';
 import Helpers from '../utils/helpers';
-import { AppState } from 'react-native';
 import { differenceInMilliseconds } from 'date-fns';
 
 /**
@@ -24,22 +23,8 @@ class EventTracker{
 
     constructor(filename) {
         this.db = new Database(filename);
-        this.appCurrentState = AppState.currentState;
-        this._handleAppStateChange = this._handleAppStateChange.bind(this);
-        this._focus = false;
     }
 
-    get isFocused() {
-        return this._focus;
-    }
-    
-    /**
-     * @param {boolean} bool
-     */
-    set setFocus(bool) {
-        if(typeof bool !== 'boolean') return;
-        this._focus = bool;
-    }
     /**
      * Adds an event to the database after performing validations.
      * 
@@ -250,113 +235,6 @@ class EventTracker{
     }
 
     /**
-     * Pauses all active events when the application moves to the background.
-     * 
-     * @async
-     * @private
-     * @name _stopEventsInBackground
-     * @description This method retrieves all active event IDs and pauses them by adding a "pause" event for each. 
-     *              It logs any errors encountered while pausing individual events and returns a list of saved timers.
-     * @returns {Promise<Array<string|null>>} A promise that resolves to an array of saved timer events or `null` if no IDs are found.
-     * @throws {EventTrackerError} If an error occurs while retrieving IDs or saving events.
-     */
-    
-    async _stopEventsInBackground () {
-        const stoppedTypes  = ['pause','finish'];
-        let stoppedEvents = [];
-
-        try {
-            const ids = await this._getAllIds()
-
-            if(!ids.length) return stoppedEvents;
-
-        for(const id of ids) {
-                const [lastEvent, lastEventError] = await Helpers.promiseWrapper(
-                    this.getLastEventById(id)
-                );
-
-                if(lastEventError) {
-                    console.warn(lastEventError)
-                }
-
-                if(stoppedTypes.includes(lastEvent?.type)) continue;
-
-                const [savedEvent, saveError] = await Helpers.promiseWrapper(
-                    this.addEvent({
-                        id,
-                        type: 'pause'
-                    })
-                )
-
-                if(saveError) {
-                    console.warn(saveError)
-                    continue;
-                }
-                stoppedEvents.push(savedEvent);
-            }
-
-            return stoppedEvents;
-        } catch (error) {
-           const customError = new EventTrackerError(error);
-           
-           return Promise.reject(customError)
-        }
-    }
-
-    /**
-     * Handles changes in the application state and performs actions based on the new state.
-     * 
-     * @async
-     * @name _handleAppStateChange
-     * @param {string} nextAppState - The next application state, e.g., 'active', 'background', etc.
-     * @description This method is triggered when the application state changes. If the app transitions from an active or foreground 
-     *              state to the background, it will pause ongoing events by calling `_stopEventsInBackground`. It then updates the 
-     *              `appCurrentState` to the new state.
-     * @returns {Promise<void>} A promise that resolves when the state change handling is complete.
-     * @throws {EventTrackerError} If an error occurs while stopping events in the background.
-     */
-    /*istanbul ignore next*/
-    async _handleAppStateChange(nextAppState) {
-        try {
-            if (this.appCurrentState.match(/active|foreground/) && nextAppState === 'background' && !this.isFocused) {
-              await this._stopEventsInBackground();
-            }
-            this.appCurrentState = nextAppState;
-        } catch(error) {
-            const customError = new EventTrackerError(error);
-
-            return Promise.reject(customError);
-        }
-      }
-
-    /**
-     * Starts listening for changes in the application state.
-     * 
-     * @name startListening
-     * @description Adds an event listener to monitor changes in the application state and calls `_handleAppStateChange` 
-     *              when the state changes.
-     * @returns {void}
-     */
-
-      /*istanbul ignore next*/
-    startListening() {
-    AppState.addEventListener('change', this._handleAppStateChange);
-    }
-
-    /**
-     * Stops listening for changes in the application state.
-     * 
-     * @name stopListening
-     * @description Removes the event listener that monitors changes in the application state and was calling `_handleAppStateChange`.
-     * @returns {void}
-     */
-
-    /*istanbul ignore next*/
-    stopListening() {
-    AppState.removeEventListener('change', this._handleAppStateChange);
-    }
-
-    /**
      * Deletes all events associated with the given ID from the database.
      * 
      * @async
@@ -404,33 +282,10 @@ class EventTracker{
 
     async removeFinishById (id) {
         try {
-            return await this.db.delete('id LIKE[c] $0 && type = $1', String(id), 'finish');
+            const dbFilters = 'id LIKE[c] $0 && type = $1'
+            return await this.db.delete(dbFilters, String(id), 'finish');
         } catch (error) {
             return Promise.reject(error);
-        }
-    }
-
-    /**
-     * Retrieves all unique event IDs from the database.
-     * 
-     * @async
-     * @private
-     * @name _getAllIds
-     * @description This method queries the database to fetch all events, extracts their IDs, and returns a list of unique IDs. 
-     *              It ensures that duplicate IDs are removed from the result.
-     * @returns {Promise<string[]>} A promise that resolves to an array of unique event IDs.
-     * @throws {Error} If an error occurs during the retrieval process.
-     */
-
-    async _getAllIds() {
-        try {
-            const events = await this.db.search();
-            const ids = events.map((ev) => (ev.id));
-            const uniqueIds = [...new Set(ids)];
-
-            return uniqueIds;
-        } catch (error) {
-            return Promise.reject(error)
         }
     }
 


### PR DESCRIPTION
LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/APPSRN-373

DESCRIPCIÓN DEL REQUERIMIENTO: *

EL CONTADOR DE TIEMPO RESTANTE FUNCIONA MAL:

Actualmente, el contador de tiempo de la aplicación de ORDERS muestra el tiempo que queda para completar la sesión realizando un calculo que resta el tiempo neto transcurrido al tiempo estimado total; por lo que, si el tiempo estimado de trabajo es de 30 minutos y el tiempo neto transcurrido fue de 10, el contador muestra un tiempo restante de 20 minutos.

Sin embargo, nos dimos cuenta que, a diferencia del contador actual que está en producción, cuando el usuario sale a 2do plano, el contador de tiempo neto queda pausado hasta que la app vuelve a funcionar en primer plano.

Esto se debe a que, cuando el usuario sale a 2do plano, se pausa el trackeo de tiempo sobre la ronda, por lo que este tiempo con la app en segundo plano y con el tracking pausado no se considera tiempo neto de trabajo y, por lo tanto, no es reflejado en el contador.

Este comportamiento, tanto de tracking como del contador, es erróneo porque no representa fehacientemente el tiempo de trabajo del usuario de cara al cliente, que espera tener un control preciso del trabajo de sus empleados.

¿CÓMO FUNCIONAN LAS PAUSAS DE LA RONDA?

Actualmente, el funcionamiento de tracking aplica pausas en el seguimiento de la ronda cuando se dan estos casos:

    la app está en segundo plano.

    la ronda es abandonada pero aún no es finalizada.

El primer caso se produce automáticamente, ya que tracking tiene un listener que le permite identificar que la app salió a segundo plano y guardar un evento de pausa para todos los ids que se encuentren en curso (en este caso, el id de la ronda).

El segundo es manual, y se realiza cuando el usuario cierra la ronda mediante la acción de logout en el flujo de picking.

NECESIDAD:
Para evitar esto se propone detener el comportamiento automático del pkg de tracking y que sólo se encargue de registrar eventos y/o manipular la información de manera voluntaria y declarativa en la implementación.

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se removieron los métodos que utilizamos para detectar el cambio de estado en la implementación de Tracking. Esto evita que, cuando se produzca el cambio de estado, tracking pause el seguimiento de todos los eventos que se encuentren en curso.


CÓMO PROBARLO?

Vincularlo a la app de picking y, en la main.js, eliminar el useEffect encargado de detectar el cambio de estado:

```js
	useEffect(() => {
		subscribeNetwork((state) => dispatch(actUpdateNetworkStatus(state)));
		return unsubscribeNetwork;
	}, []);

	// istanbul ignore next
	useEffect(() => {
		EventTracker.startListening();
		return () => {
			EventTracker.stopListening();
		};
	}, []); // Eliminar este useEffect
```

Luego, en la pantalla de Notificaciones de la app, pegar esta botonera:

```js
import React from 'react';
import t from 'src/i18n/utils/t';
import Styles from './styles';
import EventTracker from 'src/utils/eventTracker';
import Button from 'src/components/Button';
import { promiseWrapper } from '@janiscommerce/apps-helpers';

const Notifications = () => {
	
	const addEvent = async (id, type,time, payload) => {
		const [response, error] = await promiseWrapper(EventTracker.addEvent({id,type,time,payload}))

		console.log('error', error)
		console.log('response', response)
  	}
	
	const reset = async (id) => {
		const [response, error] = await promiseWrapper(EventTracker.deleteEventsById(id))
		console.log('error', error)
		console.log('response', response)
	}

	const getElapsedTime = async (id) => {
		const [events, error] = await promiseWrapper(EventTracker.getEventsById(id));

		if(error) return console.log(error);

		const {time : startTime} = events.find((event) => event.type === 'start') || {};
		const {time: finishTime} = events.find((event) => event.type === 'finish') || {};

		const elapsedTime = EventTracker.getElapsedTime({
			startTime,
			finishTime,
			format:true
		});

		console.log('elapsedTime', elapsedTime)
	}

	const getNetTime = async (id) => {
		const [events, error] = await promiseWrapper(EventTracker.getEventsById(id));

		if(error) return console.log(error);

		const netTime = EventTracker.getNetTrackingTime({
			events,
			format: true
		});

		console.log('netTime', netTime)
	}
	return (
		<Styles.Wrapper testID="notifications">
			<>
				<Button title={'iniciar seguimiento'} onPress={() => addEvent('123456789','start')}/>
				<Button title={'pausar seguimiento'} onPress={() => addEvent('123456789','pause')}/>
				<Button title={'continuar seguimiento'} onPress={() => addEvent('123456789','resume')}/>
				<Button title={'finalizar seguimiento'} onPress={() => addEvent('123456789','finish')}/>
				<Button title={'reiniciar seguimeinto'} onPress={() => reset('123456789')}/>
				<Button title={'obtener tiempo de seguimiento total'} onPress={() => getElapsedTime('123456789')}/>
				<Button title={'obtener tiempo de seguimiento NETO'} onPress={() => getNetTime('123456789')}/>
			</>
		</Styles.Wrapper>
	)
};

export default Notifications
```

Inicie el seguimiento y saque la aplicación a segundo plano. Cuando vuelva, presione el botón de pausar seguimiento, y debería poder ver en consola una respuesta similar a esta:

```js
response {"id": "123456789", "time": "2025-05-12T23:56:16.374Z"} //
```

Esto indicará que el pausado en segundo plano no se produjo, ya que pudo hacer la pausa manualmente.
En caso de que, al presionar el botón, reciba el error: `error [Error: Forbidden event: record is already paused]` significa que la pausa si se produjo y por ende, el pkg sigue trackeando en segundo plano, lo que estaría mal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed all app lifecycle event tracking and background pause functionality from event management.
  - Simplified event management by eliminating focus state handling and related methods.

- **Tests**
  - Removed tests related to app state changes, focus management, and background event pausing.

- **Documentation**
  - Removed instructions and examples for pausing events on app background and handling Android-specific focus issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->