### PR TITLE
Added method to close database after executing some action

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -12,11 +12,12 @@ class Database {
     }
 
     async save(event) {
+        let db = null;
         try {
             if(!this.filename) throw new EventTrackerError('database filename was not specified')
 
             await this._checkFolderCreation();
-            const db = await Realm.open({
+            db = await Realm.open({
                 path: this.filePath,
                 schema:[EventSchema]
             })
@@ -26,45 +27,57 @@ class Database {
             db.write(() => {
                 db.create('event',parsedEvent)
             })
-            
+
         } catch (e) {
             const customError = new EventTrackerError(e);
-
             return Promise.reject(customError);
+        } finally {
+            if (db && !db?.isClosed) db?.close();
         }
-       
     }
 
     async search(filters = '', ...values) {
+        let db = null;
         try {
             if(!this.filename) throw new EventTrackerError('database filename was not specified')
 
             await this._checkFolderCreation();
-            const db = await Realm.open({
+            db = await Realm.open({
                 path: this.filePath,
                 schema:[EventSchema]
             })
 
             const collection = db.objects('event');
 
-            if(!filters || !values) return collection;
+            let collectionCopy = collection;
+            
+            if(filters && values) {
+                collectionCopy = collection.filtered(filters,...values);
+            }
 
-            return collection.filtered(filters,...values)
+            const parsedCollection = collectionCopy.map(obj => {
+                return JSON.parse(JSON.stringify(obj));
+            });
+
+            return parsedCollection;
 
         } catch (e) {
             const customError = new EventTrackerError(e);
 
             return Promise.reject(customError);
+        } finally {
+            if (db && !db?.isClosed) db?.close();
         }
     }
 
     async delete(filters = '', ...values) {
+        let db = null;
         try {
             if(!this.filename) throw new EventTrackerError('database filename was not specified')  
             if(!filters || !values) return null;
 
             await this._checkFolderCreation();
-            const db = await Realm.open({
+            db = await Realm.open({
                 path: this.filePath,
                 schema:[EventSchema]
             })
@@ -78,17 +91,19 @@ class Database {
             })
         } catch (e) {
             const customError = new EventTrackerError(e);
-
             return Promise.reject(customError);
+        } finally {
+            if (db && !db?.isClosed) db?.close();
         }
     }
 
     async deleteAll() {
+        let db = null;
         try {
             if(!this.filename) throw new EventTrackerError('database filename was not specified')  
             
             await this._checkFolderCreation();
-            const db = await Realm.open({
+            db = await Realm.open({
                 path: this.filePath,
                 schema:[EventSchema]
             })
@@ -98,8 +113,9 @@ class Database {
             })
         } catch (e) {
             const customError = new EventTrackerError(e);
-
             return Promise.reject(customError);
+        } finally {
+            if (db && !db?.isClosed) db?.close();
         }
     }
 


### PR DESCRIPTION
### LINK DE TICKET: 
https://janiscommerce.atlassian.net/browse/APPSRN-387

### CONTEXTO:

Actualmente, en el package de app-tracking-time del equipo de apps, estamos implementando realm como base de datos local. Esta base de datos nos permite hacer un seguimiento sobre el tiempo que dedica a un usuario a realizar tareas relacionadas a un id, identificando:
- A qué hora empezó a trabajar.
- A qué hora finalizó el trabajo.
- Si tuvo momentos de pausa.
- La hora en que concluyeron esas pausas.

### SITUACIÓN:

Revisando el código, detectamos que, ante cada acción que se realiza en la base de datos, no se implementa su correspondiente acción de cierre para liberar recursos.

# DESCRIPCIÓN DEL REQUERIMIENTO:

Se requiere agregar la acción de cierre ya que, al mantener la DB abierta, no se liberan los recursos utilizados durante el trabajo en la DB, lo que implica ocupar memoria del sistema innecesariamente y reducir el rendimiento general de la aplicación.

Además, agregar el cierre de la base de datos es importante para:
- prevenir la corrupción de datos.
- mejorar la estabilidad de la aplicación

# DESCRIPCIÓN DE LA SOLUCIÓN:

Se agregó un bloque `finally` en los métodos [`save`,`search`,`delete`,`deleteAll`] de la clase `database`. Este bloque se encarga de validar el estado de la base y ejecutar el método `close` de `realm` para cerrarla luego de la ejecución de cualquier metodo que interactúe y abra la base de datos.

También se hizo un ajuste en el método `search` para que, en vez de devolver la información obtenida de realm, devuelva una copia de los eventos almacenados en la base de datos.
Esto debido a que, a partir de que empezamos a usar el método `close`, realm estaba devolviendo el siguiente error:

```js
[Error: Exception in HostFunction: Access to invalidated Results objects]
```

El error en cuestión se debe a que, al cerrar la base de datos, se perdía el acceso a esta información, lo que impedía el correcto funcionamiento de los métodos que dependían de `search`.


## CÓMO SE PUEDE PROBAR?

La forma más eficiente de probar el funcionamiento del pkg sería vincularlo a la app de order, que es la única app que actualmente usa el pkg.

Para eso, cree una nueva branch que parta desde master y luego vincule el pkg al repo con yalc.

Una vez que lo vincule haga las siguientes pruebas:

- Abra flipper
- Arranque una ronda (puede ser nueva o vieja) en el flujo de picking.
- Pickee cada producto de la misma con o sin internet.

| CASO | COMPORTAMIENTO ESPERADO |
|--------|--------|
| Producto pickeado / skipeado / marcado como faltante con internet | La request PATCH debe enviar la información de tracking asociada al producto |
| Producto pickeado / skipeado / marcado como faltante sin internet | No se realiza la request, pero la información de tracking queda almacenada en redux para ser enviada cuando se finalice la ronda |
| Se completa la ronda de tracking o se la abandona mediante la acción de logout | se ejecuta la función `removeTrackingEvents` y no se reciben errores por parte de la base de datos |

La app debería mantener su comportamiento habitual, ya que estos cambios no afectan el funcionamiento de los métodos de la base de datos de tracking, sino que lo complementan
