### PR TITLE
added searchEvent method

### DIFF
--- a/__test__/eventTracker.test.js
+++ b/__test__/eventTracker.test.js
@@ -1,358 +1,439 @@
-import EventTracker from "../lib/event-tracker";
-import Database from "../lib/database";
-import Helpers from "../utils/helpers";
-
-jest.mock('../lib/database')
-
-describe('EventTracker class', () => { 
-
-    const DEFAULT_ELAPSED_TIME = {
-        days: 0,
-        hours: 0,
-        minutes:0,
-        seconds: 0,
-    }
-
-    const eventTracker = new EventTracker('timetracker');
-    const saveFn = Database.prototype.save;
-    const searchFn = Database.prototype.search;
-    const deleteFn = Database.prototype.delete;
-    const deleteAllFn = Database.prototype.deleteAll;
-    const removeDatabaseFolderFn = Database.prototype.removeDatabaseFolder;
-
-    const diffTimeMock = jest.spyOn(Helpers,'getTimeDifference')
-    const mockDate = new Date('2023-01-01T00:15:00.000Z');
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    describe('return methods to handler time events', () => { 
-        it('when the class is instantiated', () => {
-
-            expect(typeof eventTracker.addEvent).toBe('function');
-        })
-    })
-    describe('addEvent method', () => { 
-        describe('throws an error when', () => { 
-            it('passed id is invalid',async () => {
-
-                expect(eventTracker.addEvent({id:null})).rejects.toThrow('ID is invalid or null') 
-            })
-
-            it('passed type is invalid',async () => {
-
-                expect(eventTracker.addEvent({id:'123',type:'fakeStart'})).rejects.toThrow("Event type is invalid") 
-            })
-        })
-
-        describe('add an event when', () => { 
-            it('id and type are valids', async () => {
-                searchFn.mockResolvedValueOnce([]);
-                const response = await eventTracker.addEvent({id:'345',type:'start'})
-                expect(response).toBeTruthy()
-            })
-        })
-    })
-    describe('getEventsById method', () => { 
-        describe('throws an error when', () => { 
-            it('id isnt valid', () => {
-                expect(eventTracker.getEventsById(12345)).rejects.toThrow('ID is invalid or null')
-            })
-        })
-        
-        describe('return an array with', () => { 
-            it('related events when id is valid', async () => {
-                searchFn.mockResolvedValueOnce([
-                    {id:'345',type:'start',time:'2023-01-01T00:00:00.000Z', payload:'{}'},
-                    {id:'345',type:'pause',time:'2023-01-01T00:00:00.000Z', payload:'{}'}
-                ]);
-
-                const response = await eventTracker.getEventsById('345');
-
-                expect(response).toStrictEqual([
-                    {id:'345',type:'start',time:'2023-01-01T00:00:00.000Z', payload:{}},
-                    {id:'345',type:'pause',time:'2023-01-01T00:00:00.000Z', payload:{}}
-                ])
-            })
-         })
-    })
-
-    describe('getLastEventById mehtod', () => { 
-        describe('throws an error', () => { 
-            it('when received id is invalid', () => {
-                expect(eventTracker.getLastEventById(null)).rejects.toThrow('ID is invalid or null')
-            })
-        })
-        
-        it('return last event type registered', async () => {
-            searchFn.mockResolvedValueOnce([
-                {id:'345',type:'start'},
-                {id:'345',type:'pause'},
-                {id:'345',type:'resume',payload: '{"userId":"123","warehouseId":"123-wh"}', time:'2023-01-01T00:00:00.000Z'}
-            ]);
-
-            const typeResponse = await eventTracker.getLastEventById('345');
-
-            expect(typeResponse).toStrictEqual({id:'345',type:'resume',time:'2023-01-01T00:00:00.000Z',payload: {userId:'123',warehouseId:'123-wh'}});
-        })
-    })
-
-    describe('getElapsedTime method', () => {
-
-        describe('return default elapsedTime', () => { 
-            it('should return default elapsedTime when startTime is null', () => {
-                expect(eventTracker.getElapsedTime({})).toStrictEqual(DEFAULT_ELAPSED_TIME)
-            })
-
-            it('should return 0 when startTime is null and format is false', () => {
-                expect(eventTracker.getElapsedTime({format:false})).toStrictEqual(0)
-            })
-         })
-
-        describe('return elasped time', () => { 
-            it('between started time and finish time', () => {
-                const startTime = '2023-01-01T00:00:00.000Z';
-                const finishTime = '2023-01-01T00:30:00.000Z'
-
-                diffTimeMock.mockReturnValueOnce({
-                    days:0,
-                    hours:0,
-                    minutes:30,
-                    seconds:0
-                })
-
-                const response = eventTracker.getElapsedTime({startTime,finishTime})
-                expect(response).toStrictEqual({
-                    days:0,
-                    hours:0,
-                    minutes:30,
-                    seconds:0
-                })
-            })
-         })
-
-         it('but, if the id hasnt finish time, la comparación se realizará contra la hora actual', async () => {
-            jest.spyOn(mockDate, 'toISOString').mockReturnValueOnce('2023-01-01T00:15:00.000Z');
-
-            diffTimeMock.mockReturnValueOnce(60116031652)
-
-            const startTime = '2023-01-01T00:00:00.000Z';
-
-            const response = eventTracker.getElapsedTime({startTime, format: false})
-
-            expect(response).toStrictEqual(60116031652)
-         })
-    })
-
-    describe('getStoppedTime method', () => {
-
-        describe('return 0', () => {
-          it('should return 0  if not pass events or this is an empty array', () => {
-            const response = eventTracker.getStoppedTime({})
-
-            expect(response).toStrictEqual(0)
-          })
-        })
-        
-        describe('should return stopped time', () => {
-
-          it('should return stopped time in time format if format params is true', () => {
-            const registeredEvents = [
-                {id:'345',type:'pause',time:'2023-01-01T00:00:10.000Z'},
-                {id:'345',type:'pause',time:'2023-01-01T00:00:10.000Z'},
-                {id:'345',type:'resume', time:'2023-01-01T00:00:20.000Z'},
-                {id:'345',type:'pause',time:'2023-01-01T00:00:40.000Z'},
-                {id:'345',type:'pause',time:'2023-01-01T00:01:00.000Z'},
-                {id:'345',type:'resume', time:'2023-01-01T00:01:20.000Z'},
-            ]
-
-            const response = eventTracker.getStoppedTime({events:registeredEvents, format:true});
-
-            expect(response).toStrictEqual({"days": 0, "hours": 0, "minutes": 0, "seconds": 30})
-          })
-        })
-        
-    })
-
-    describe('getNetTrackingTime method', () => {
-
-        describe('return 0', () => {
-            it('should return 0 when not receive a valid array as argument ', () => {
-            const response = eventTracker.getNetTrackingTime({});
-
-            expect(response).toStrictEqual(0);
-            })
-            
-            it('should return 0 when elapsed time is 0 or less than 0', () => {
-                const events = [
-                    {id:'345',type:'start',time:'2023-01-01T00:00:10.000Z'},
-                    {id:'345',type:'finish', time:'2023-01-01T00:00:10.000Z'}
-                ]
-
-                const response = eventTracker.getNetTrackingTime({events});
-
-                expect(response).toStrictEqual(0);
-            })
-        })
-
-        describe('should return net tracked time', () => {
-            it('should return net tracking time when get elapsed time and discount paused time', () => {
-                const events = [
-                    {id:'345',type:'start',time:'2023-01-01T00:00:10.000Z'},
-                    {id:'345',type:'pause',time:'2023-01-01T00:00:15.000Z'},
-                    {id:'345',type:'resume', time:'2023-01-01T00:00:40.000Z'},
-                    {id:'345',type:'finish', time:'2023-01-01T00:00:50.000Z'}
-                ]
-
-                const response = eventTracker.getNetTrackingTime({events});
-
-                expect(response).toStrictEqual(15000);
-                })
-            it('should return formatted net tracking time when get elapsed time and discount paused time, but format argument is true', () => {
-                const events = [
-                    {id:'345',type:'start',time:'2023-01-01T00:00:10.000Z'},
-                    {id:'345',type:'pause',time:'2023-01-01T00:00:15.000Z'},
-                    {id:'345',type:'resume', time:'2023-01-01T00:00:40.000Z'},
-                    {id:'345',type:'finish', time:'2023-01-01T00:00:50.000Z'}
-                ]
-    
-                const response = eventTracker.getNetTrackingTime({events, format:true});
-    
-                expect(response).toStrictEqual({"days": 0, "hours": 0, "minutes": 0, "seconds": 15});
-            }) 
-        })
-    })
-    
-
-    describe('deleteEventsById method', () => { 
-        describe('throws an error when', () => { 
-            it('id is invalid or null', () => {
-                expect(eventTracker.deleteEventsById()).rejects.toThrow('ID is invalid or null');
-            })
-        })
-
-        describe('delete events related to id', () => { 
-            it('when the request complete successfully', async () => {
-                deleteFn.mockResolvedValueOnce();
-
-                await eventTracker.deleteEventsById('123')
-
-                expect(deleteFn).toHaveBeenCalled();
-            })
-         })
-    })
-
-    describe('deleteAllEvents method', () => { 
-        describe('throws an error when  ', () => { 
-            it('delete fails', async () => {
-                deleteAllFn.mockRejectedValueOnce('error');
-
-                const [, error] = await Helpers.promiseWrapper(
-                    eventTracker.deleteAllEvents()
-                )
-
-                expect(error).toStrictEqual('error')
-            })
-        })
-
-        describe('wipe database when', () => {
-            it('database request complete successfully', async () => {
-                deleteAllFn.mockResolvedValueOnce();
-
-                await eventTracker.deleteAllEvents();
-
-                expect(deleteAllFn).toHaveBeenCalled();
-            })
-        })
-    })
-
-    describe('isEventStarted method', () => { 
-        describe('throws an error when', () => { 
-            it('id is invalid or null', () => {
-                expect(eventTracker.isEventStarted()).rejects.toThrow('ID is invalid or null')
-            })
-        })
-
-        describe('returns a boolean indicating whether the id was started or not', () => { 
-            it('if id is started, return true', async () => {
-                searchFn.mockResolvedValueOnce([{id:'123',type:'start'}])
-
-                const response = await eventTracker.isEventStarted('123');
-
-                expect(response).toBeTruthy()
-            })
-
-            it('return false when the id wasnt initialized', async () => {
-                searchFn.mockResolvedValueOnce([]);
-                const response = await eventTracker.isEventStarted('345');
-
-                expect(response).toBeFalsy();
-                
-            })
-        })
-    })
-
-    describe('removeFinishById method', () => { 
-        it('remove finish event when delete database method resolved correctly', async () => {
-            deleteFn.mockResolvedValueOnce();
-
-            await eventTracker.removeFinishById('123')
-
-            expect(deleteFn).toHaveBeenCalled();
-        })
-
-        it('return a reject promise when delete method fails', async () => {
-            deleteFn.mockRejectedValueOnce(new Error('delete error'));
-
-            await expect(eventTracker.removeFinishById('123')).rejects.toThrow('delete error')
-        })
-    })
-
-    describe('getIdTimeByType method', () => { 
-        describe('throws an error when', () => { 
-            it('passed id is invalid',async () => {
-                expect(eventTracker.getIdTimeByType()).rejects.toThrow('ID is invalid or null') 
-            })
-
-            it('passed type is invalid',async () => {
-                expect(eventTracker.getIdTimeByType('123','fakeStart')).rejects.toThrow("Event type is invalid") 
-            })
-        })
-
-        describe('return null', () => { 
-            it('should return null when finded event not contains time key', async () => {
-                searchFn.mockResolvedValueOnce([{id:'123',type:'start',payload:{}}])
-
-                const time = await eventTracker.getIdTimeByType('123','start');
-
-                expect(time).toBeNull();
-            })
-         })
-
-        describe('return time value', () => { 
-            it('should return time register value when has valid type, valid id and valid time', async () => {
-                searchFn.mockResolvedValueOnce([{id:'123',type:'start',payload:{}, time: '2023-01-02T00:00:00.000Z'}])
-
-                const time = await eventTracker.getIdTimeByType('123','start');
-
-                expect(time).toStrictEqual('2023-01-02T00:00:00.000Z')
-            })
-         })
-     })
-
-    describe('removeEventsFolder method', () => { 
-        describe('delete database', () => { 
-            it('should delete database if removeDatabase complete successfully', async () => {
-                removeDatabaseFolderFn.mockResolvedValueOnce();
-
-                await eventTracker.removeEventsFolder();
-
-                expect(removeDatabaseFolderFn).toHaveBeenCalled();
-            })
-
-            it('should return a reject promise when remove method fails', async () => {
-                removeDatabaseFolderFn.mockRejectedValueOnce(new Error('delete error'));
-
-                await expect(eventTracker.removeEventsFolder()).rejects.toThrow('delete error')
-            })
-         })
-    })
- })
+import EventTracker from '../lib/event-tracker';
+import Database from '../lib/database';
+import Helpers from '../utils/helpers';
+
+jest.mock('../lib/database');
+
+describe('EventTracker class', () => {
+	const DEFAULT_ELAPSED_TIME = {
+		days: 0,
+		hours: 0,
+		minutes: 0,
+		seconds: 0,
+	};
+
+	const eventTracker = new EventTracker('timetracker');
+	const saveFn = Database.prototype.save;
+	const searchFn = Database.prototype.search;
+	const deleteFn = Database.prototype.delete;
+	const deleteAllFn = Database.prototype.deleteAll;
+	const removeDatabaseFolderFn = Database.prototype.removeDatabaseFolder;
+
+	const diffTimeMock = jest.spyOn(Helpers, 'getTimeDifference');
+	const mockDate = new Date('2023-01-01T00:15:00.000Z');
+	jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+	describe('return methods to handler time events', () => {
+		it('when the class is instantiated', () => {
+			expect(typeof eventTracker.addEvent).toBe('function');
+		});
+	});
+	describe('addEvent method', () => {
+		describe('throws an error when', () => {
+			it('passed id is invalid', async () => {
+				expect(eventTracker.addEvent({id: null})).rejects.toThrow('ID is invalid or null');
+			});
+
+			it('passed type is invalid', async () => {
+				expect(eventTracker.addEvent({id: '123', type: 'fakeStart'})).rejects.toThrow(
+					'Event type is invalid',
+				);
+			});
+		});
+
+		describe('add an event when', () => {
+			it('id and type are valids', async () => {
+				searchFn.mockResolvedValueOnce([]);
+				const response = await eventTracker.addEvent({id: '345', type: 'start'});
+				expect(response).toBeTruthy();
+			});
+		});
+	});
+	describe('getEventsById method', () => {
+		describe('throws an error when', () => {
+			it('id isnt valid', () => {
+				expect(eventTracker.getEventsById(12345)).rejects.toThrow('ID is invalid or null');
+			});
+		});
+
+		describe('return an array with', () => {
+			it('related events when id is valid', async () => {
+				searchFn.mockResolvedValueOnce([
+					{id: '345', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: '{}'},
+					{id: '345', type: 'pause', time: '2023-01-01T00:00:00.000Z', payload: '{}'},
+				]);
+
+				const response = await eventTracker.getEventsById('345');
+
+				expect(response).toStrictEqual([
+					{id: '345', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: {}},
+					{id: '345', type: 'pause', time: '2023-01-01T00:00:00.000Z', payload: {}},
+				]);
+			});
+		});
+	});
+
+	describe('getLastEventById mehtod', () => {
+		describe('throws an error', () => {
+			it('when received id is invalid', () => {
+				expect(eventTracker.getLastEventById(null)).rejects.toThrow('ID is invalid or null');
+			});
+		});
+
+		it('return last event type registered', async () => {
+			searchFn.mockResolvedValueOnce([
+				{id: '345', type: 'start'},
+				{id: '345', type: 'pause'},
+				{
+					id: '345',
+					type: 'resume',
+					payload: '{"userId":"123","warehouseId":"123-wh"}',
+					time: '2023-01-01T00:00:00.000Z',
+				},
+			]);
+
+			const typeResponse = await eventTracker.getLastEventById('345');
+
+			expect(typeResponse).toStrictEqual({
+				id: '345',
+				type: 'resume',
+				time: '2023-01-01T00:00:00.000Z',
+				payload: {userId: '123', warehouseId: '123-wh'},
+			});
+		});
+	});
+
+	describe('getElapsedTime method', () => {
+		describe('return default elapsedTime', () => {
+			it('should return default elapsedTime when startTime is null', () => {
+				expect(eventTracker.getElapsedTime({})).toStrictEqual(DEFAULT_ELAPSED_TIME);
+			});
+
+			it('should return 0 when startTime is null and format is false', () => {
+				expect(eventTracker.getElapsedTime({format: false})).toStrictEqual(0);
+			});
+		});
+
+		describe('return elasped time', () => {
+			it('between started time and finish time', () => {
+				const startTime = '2023-01-01T00:00:00.000Z';
+				const finishTime = '2023-01-01T00:30:00.000Z';
+
+				diffTimeMock.mockReturnValueOnce({
+					days: 0,
+					hours: 0,
+					minutes: 30,
+					seconds: 0,
+				});
+
+				const response = eventTracker.getElapsedTime({startTime, finishTime});
+				expect(response).toStrictEqual({
+					days: 0,
+					hours: 0,
+					minutes: 30,
+					seconds: 0,
+				});
+			});
+		});
+
+		it('but, if the id hasnt finish time, la comparación se realizará contra la hora actual', async () => {
+			jest.spyOn(mockDate, 'toISOString').mockReturnValueOnce('2023-01-01T00:15:00.000Z');
+
+			diffTimeMock.mockReturnValueOnce(60116031652);
+
+			const startTime = '2023-01-01T00:00:00.000Z';
+
+			const response = eventTracker.getElapsedTime({startTime, format: false});
+
+			expect(response).toStrictEqual(60116031652);
+		});
+	});
+
+	describe('getStoppedTime method', () => {
+		describe('return 0', () => {
+			it('should return 0  if not pass events or this is an empty array', () => {
+				const response = eventTracker.getStoppedTime({});
+
+				expect(response).toStrictEqual(0);
+			});
+		});
+
+		describe('should return stopped time', () => {
+			it('should return stopped time in time format if format params is true', () => {
+				const registeredEvents = [
+					{id: '345', type: 'pause', time: '2023-01-01T00:00:10.000Z'},
+					{id: '345', type: 'pause', time: '2023-01-01T00:00:10.000Z'},
+					{id: '345', type: 'resume', time: '2023-01-01T00:00:20.000Z'},
+					{id: '345', type: 'pause', time: '2023-01-01T00:00:40.000Z'},
+					{id: '345', type: 'pause', time: '2023-01-01T00:01:00.000Z'},
+					{id: '345', type: 'resume', time: '2023-01-01T00:01:20.000Z'},
+				];
+
+				const response = eventTracker.getStoppedTime({events: registeredEvents, format: true});
+
+				expect(response).toStrictEqual({days: 0, hours: 0, minutes: 0, seconds: 30});
+			});
+		});
+	});
+
+	describe('getNetTrackingTime method', () => {
+		describe('return 0', () => {
+			it('should return 0 when not receive a valid array as argument ', () => {
+				const response = eventTracker.getNetTrackingTime({});
+
+				expect(response).toStrictEqual(0);
+			});
+
+			it('should return 0 when elapsed time is 0 or less than 0', () => {
+				const events = [
+					{id: '345', type: 'start', time: '2023-01-01T00:00:10.000Z'},
+					{id: '345', type: 'finish', time: '2023-01-01T00:00:10.000Z'},
+				];
+
+				const response = eventTracker.getNetTrackingTime({events});
+
+				expect(response).toStrictEqual(0);
+			});
+		});
+
+		describe('should return net tracked time', () => {
+			it('should return net tracking time when get elapsed time and discount paused time', () => {
+				const events = [
+					{id: '345', type: 'start', time: '2023-01-01T00:00:10.000Z'},
+					{id: '345', type: 'pause', time: '2023-01-01T00:00:15.000Z'},
+					{id: '345', type: 'resume', time: '2023-01-01T00:00:40.000Z'},
+					{id: '345', type: 'finish', time: '2023-01-01T00:00:50.000Z'},
+				];
+
+				const response = eventTracker.getNetTrackingTime({events});
+
+				expect(response).toStrictEqual(15000);
+			});
+			it('should return formatted net tracking time when get elapsed time and discount paused time, but format argument is true', () => {
+				const events = [
+					{id: '345', type: 'start', time: '2023-01-01T00:00:10.000Z'},
+					{id: '345', type: 'pause', time: '2023-01-01T00:00:15.000Z'},
+					{id: '345', type: 'resume', time: '2023-01-01T00:00:40.000Z'},
+					{id: '345', type: 'finish', time: '2023-01-01T00:00:50.000Z'},
+				];
+
+				const response = eventTracker.getNetTrackingTime({events, format: true});
+
+				expect(response).toStrictEqual({days: 0, hours: 0, minutes: 0, seconds: 15});
+			});
+		});
+	});
+
+	describe('deleteEventsById method', () => {
+		describe('throws an error when', () => {
+			it('id is invalid or null', () => {
+				expect(eventTracker.deleteEventsById()).rejects.toThrow('ID is invalid or null');
+			});
+		});
+
+		describe('delete events related to id', () => {
+			it('when the request complete successfully', async () => {
+				deleteFn.mockResolvedValueOnce();
+
+				await eventTracker.deleteEventsById('123');
+
+				expect(deleteFn).toHaveBeenCalled();
+			});
+		});
+	});
+
+	describe('deleteAllEvents method', () => {
+		describe('throws an error when  ', () => {
+			it('delete fails', async () => {
+				deleteAllFn.mockRejectedValueOnce('error');
+
+				const [, error] = await Helpers.promiseWrapper(eventTracker.deleteAllEvents());
+
+				expect(error).toStrictEqual('error');
+			});
+		});
+
+		describe('wipe database when', () => {
+			it('database request complete successfully', async () => {
+				deleteAllFn.mockResolvedValueOnce();
+
+				await eventTracker.deleteAllEvents();
+
+				expect(deleteAllFn).toHaveBeenCalled();
+			});
+		});
+	});
+
+	describe('isEventStarted method', () => {
+		describe('throws an error when', () => {
+			it('id is invalid or null', () => {
+				expect(eventTracker.isEventStarted()).rejects.toThrow('ID is invalid or null');
+			});
+		});
+
+		describe('returns a boolean indicating whether the id was started or not', () => {
+			it('if id is started, return true', async () => {
+				searchFn.mockResolvedValueOnce([{id: '123', type: 'start'}]);
+
+				const response = await eventTracker.isEventStarted('123');
+
+				expect(response).toBeTruthy();
+			});
+
+			it('return false when the id wasnt initialized', async () => {
+				searchFn.mockResolvedValueOnce([]);
+				const response = await eventTracker.isEventStarted('345');
+
+				expect(response).toBeFalsy();
+			});
+		});
+	});
+
+	describe('removeFinishById method', () => {
+		it('remove finish event when delete database method resolved correctly', async () => {
+			deleteFn.mockResolvedValueOnce();
+
+			await eventTracker.removeFinishById('123');
+
+			expect(deleteFn).toHaveBeenCalled();
+		});
+
+		it('return a reject promise when delete method fails', async () => {
+			deleteFn.mockRejectedValueOnce(new Error('delete error'));
+
+			await expect(eventTracker.removeFinishById('123')).rejects.toThrow('delete error');
+		});
+	});
+
+	describe('getIdTimeByType method', () => {
+		describe('throws an error when', () => {
+			it('passed id is invalid', async () => {
+				expect(eventTracker.getIdTimeByType()).rejects.toThrow('ID is invalid or null');
+			});
+
+			it('passed type is invalid', async () => {
+				expect(eventTracker.getIdTimeByType('123', 'fakeStart')).rejects.toThrow(
+					'Event type is invalid',
+				);
+			});
+		});
+
+		describe('return null', () => {
+			it('should return null when finded event not contains time key', async () => {
+				searchFn.mockResolvedValueOnce([{id: '123', type: 'start', payload: {}}]);
+
+				const time = await eventTracker.getIdTimeByType('123', 'start');
+
+				expect(time).toBeNull();
+			});
+		});
+
+		describe('return time value', () => {
+			it('should return time register value when has valid type, valid id and valid time', async () => {
+				searchFn.mockResolvedValueOnce([
+					{id: '123', type: 'start', payload: {}, time: '2023-01-02T00:00:00.000Z'},
+				]);
+
+				const time = await eventTracker.getIdTimeByType('123', 'start');
+
+				expect(time).toStrictEqual('2023-01-02T00:00:00.000Z');
+			});
+		});
+	});
+
+	describe('removeEventsFolder method', () => {
+		describe('delete database', () => {
+			it('should delete database if removeDatabase complete successfully', async () => {
+				removeDatabaseFolderFn.mockResolvedValueOnce();
+
+				await eventTracker.removeEventsFolder();
+
+				expect(removeDatabaseFolderFn).toHaveBeenCalled();
+			});
+
+			it('should return a reject promise when remove method fails', async () => {
+				removeDatabaseFolderFn.mockRejectedValueOnce(new Error('delete error'));
+
+				await expect(eventTracker.removeEventsFolder()).rejects.toThrow('delete error');
+			});
+		});
+	});
+
+	describe('searchEventByQuery method', () => {
+		describe('return all events when', () => {
+			it('no query is provided', async () => {
+				const mockEvents = [
+					{id: '123', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: '{}'},
+					{id: '456', type: 'pause', time: '2023-01-01T00:00:10.000Z', payload: '{}'},
+				];
+				searchFn.mockResolvedValueOnce(mockEvents);
+
+				const response = await eventTracker.searchEventByQuery();
+
+				expect(searchFn).toHaveBeenCalledWith('', ...[]);
+				expect(response).toStrictEqual(mockEvents);
+			});
+		});
+
+		describe('return filtered events when', () => {
+			it('searching by ID', async () => {
+				const mockEvents = [
+					{id: '123', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: '{}'},
+					{id: '123', type: 'pause', time: '2023-01-01T00:00:10.000Z', payload: '{}'},
+				];
+				searchFn.mockResolvedValueOnce(mockEvents);
+
+				const response = await eventTracker.searchEventByQuery('id == $0', '123');
+
+				expect(searchFn).toHaveBeenCalledWith('id == $0', '123');
+				expect(response).toStrictEqual(mockEvents);
+			});
+
+			it('searching by type', async () => {
+				const mockEvents = [
+					{id: '123', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: '{}'},
+					{id: '456', type: 'start', time: '2023-01-01T00:00:05.000Z', payload: '{}'},
+				];
+				searchFn.mockResolvedValueOnce(mockEvents);
+
+				const response = await eventTracker.searchEventByQuery('type == $0', 'start');
+
+				expect(searchFn).toHaveBeenCalledWith('type == $0', 'start');
+				expect(response).toStrictEqual(mockEvents);
+			});
+
+			it('searching with complex query', async () => {
+				const mockEvents = [
+					{id: '123', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: '{}'},
+				];
+				searchFn.mockResolvedValueOnce(mockEvents);
+
+				const response = await eventTracker.searchEventByQuery(
+					'id == $0 && type == $1 && time >= $2',
+					'123',
+					'start',
+					new Date('2023-01-01'),
+				);
+
+				expect(searchFn).toHaveBeenCalledWith(
+					'id == $0 && type == $1 && time >= $2',
+					'123',
+					'start',
+					new Date('2023-01-01'),
+				);
+				expect(response).toStrictEqual(mockEvents);
+			});
+		});
+
+		describe('throws an error when', () => {
+			it('database search fails', async () => {
+				const errorMessage = 'Database search error';
+				searchFn.mockRejectedValueOnce(new Error(errorMessage));
+
+				await expect(eventTracker.searchEventByQuery('id == $0', '123')).rejects.toThrow(
+					errorMessage,
+				);
+			});
+		});
+	});
+});

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,169 +1,167 @@
 import Realm from 'realm';
 import RNFS from 'react-native-fs';
-import Event from './event'
+import Event from './event';
 import EventTrackerError from './event-tracker-error';
 import EventSchema from '../db/schemas/eventSchema';
 
 class Database {
-    constructor(filename) {
-        this.filename = filename;
-        this.path = `${RNFS.DocumentDirectoryPath}/realm/timetracker`;
-        this.filePath = `${this.path}/${this.filename}.realm`;
-    }
+	constructor(filename) {
+		this.filename = filename;
+		this.path = `${RNFS.DocumentDirectoryPath}/realm/timetracker`;
+		this.filePath = `${this.path}/${this.filename}.realm`;
+	}
 
-    async save(event) {
-        let db = null;
-        try {
-            if(!this.filename) throw new EventTrackerError('database filename was not specified')
+	async save(event) {
+		let db = null;
+		try {
+			if (!this.filename) throw new EventTrackerError('database filename was not specified');
 
-            await this._checkFolderCreation();
-            db = await Realm.open({
-                path: this.filePath,
-                schema:[EventSchema]
-            })
+			await this._checkFolderCreation();
+			db = await Realm.open({
+				path: this.filePath,
+				schema: [EventSchema],
+			});
 
-            const parsedEvent = Event.parseEventForDB(event);
+			const parsedEvent = Event.parseEventForDB(event);
 
-            db.write(() => {
-                db.create('event',parsedEvent)
-            })
+			db.write(() => {
+				db.create('event', parsedEvent);
+			});
+		} catch (e) {
+			const customError = new EventTrackerError(e);
+			return Promise.reject(customError);
+		} finally {
+			if (db && !db?.isClosed) db?.close();
+		}
+	}
 
-        } catch (e) {
-            const customError = new EventTrackerError(e);
-            return Promise.reject(customError);
-        } finally {
-            if (db && !db?.isClosed) db?.close();
-        }
-    }
+	async search(filters = '', ...values) {
+		let db = null;
+		try {
+			if (!this.filename) throw new EventTrackerError('database filename was not specified');
 
-    async search(filters = '', ...values) {
-        let db = null;
-        try {
-            if(!this.filename) throw new EventTrackerError('database filename was not specified')
+			await this._checkFolderCreation();
+			db = await Realm.open({
+				path: this.filePath,
+				schema: [EventSchema],
+			});
 
-            await this._checkFolderCreation();
-            db = await Realm.open({
-                path: this.filePath,
-                schema:[EventSchema]
-            })
+			const collection = db.objects('event');
 
-            const collection = db.objects('event');
+			let collectionCopy = collection;
 
-            let collectionCopy = collection;
-            
-            if(filters && values) {
-                collectionCopy = collection.filtered(filters,...values);
-            }
+			if (filters) {
+				collectionCopy = collection.filtered(filters, ...values);
+			}
 
-            const parsedCollection = collectionCopy.map(obj => {
-                return JSON.parse(JSON.stringify(obj));
-            });
+			const parsedCollection = collectionCopy.map((obj) => {
+				return JSON.parse(JSON.stringify(obj));
+			});
 
-            return parsedCollection;
+			return parsedCollection;
+		} catch (e) {
+			const customError = new EventTrackerError(e);
 
-        } catch (e) {
-            const customError = new EventTrackerError(e);
+			return Promise.reject(customError);
+		} finally {
+			if (db && !db?.isClosed) db?.close();
+		}
+	}
 
-            return Promise.reject(customError);
-        } finally {
-            if (db && !db?.isClosed) db?.close();
-        }
-    }
+	async delete(filters = '', ...values) {
+		let db = null;
+		try {
+			if (!this.filename) throw new EventTrackerError('database filename was not specified');
+			if (!filters || !values) return null;
 
-    async delete(filters = '', ...values) {
-        let db = null;
-        try {
-            if(!this.filename) throw new EventTrackerError('database filename was not specified')  
-            if(!filters || !values) return null;
+			await this._checkFolderCreation();
+			db = await Realm.open({
+				path: this.filePath,
+				schema: [EventSchema],
+			});
 
-            await this._checkFolderCreation();
-            db = await Realm.open({
-                path: this.filePath,
-                schema:[EventSchema]
-            })
+			const collection = db.objects('event');
 
-            const collection = db.objects('event');
+			const events = collection.filtered(filters, ...values);
 
-            const events = collection.filtered(filters,...values)
+			db.write(() => {
+				db.delete(events);
+			});
+		} catch (e) {
+			const customError = new EventTrackerError(e);
+			return Promise.reject(customError);
+		} finally {
+			if (db && !db?.isClosed) db?.close();
+		}
+	}
 
-            db.write(() => {
-                db.delete(events);
-            })
-        } catch (e) {
-            const customError = new EventTrackerError(e);
-            return Promise.reject(customError);
-        } finally {
-            if (db && !db?.isClosed) db?.close();
-        }
-    }
+	async deleteAll() {
+		let db = null;
+		try {
+			if (!this.filename) throw new EventTrackerError('database filename was not specified');
 
-    async deleteAll() {
-        let db = null;
-        try {
-            if(!this.filename) throw new EventTrackerError('database filename was not specified')  
-            
-            await this._checkFolderCreation();
-            db = await Realm.open({
-                path: this.filePath,
-                schema:[EventSchema]
-            })
+			await this._checkFolderCreation();
+			db = await Realm.open({
+				path: this.filePath,
+				schema: [EventSchema],
+			});
 
-            db.write(() => {
-                db.deleteAll()
-            })
-        } catch (e) {
-            const customError = new EventTrackerError(e);
-            return Promise.reject(customError);
-        } finally {
-            if (db && !db?.isClosed) db?.close();
-        }
-    }
+			db.write(() => {
+				db.deleteAll();
+			});
+		} catch (e) {
+			const customError = new EventTrackerError(e);
+			return Promise.reject(customError);
+		} finally {
+			if (db && !db?.isClosed) db?.close();
+		}
+	}
 
-    async isFolderAvailable() {
-        try {
-            const folderPath = this.path;
-            return await RNFS.exists(folderPath)
-        } catch(error) {
-            return false;
-        }
-    }
+	async isFolderAvailable() {
+		try {
+			const folderPath = this.path;
+			return await RNFS.exists(folderPath);
+		} catch (error) {
+			return false;
+		}
+	}
 
-    async removeDatabaseFolder() {
-        try {
-            const folderExist = await this.isFolderAvailable();
+	async removeDatabaseFolder() {
+		try {
+			const folderExist = await this.isFolderAvailable();
 
-            if(!folderExist) return null;
-            const folderPath = this.path;
+			if (!folderExist) return null;
+			const folderPath = this.path;
 
-            await RNFS.unlink(folderPath)
-            
-            return true;
-        } catch (error) {
-            const customError = new EventTrackerError(error);
+			await RNFS.unlink(folderPath);
 
-            return Promise.reject(customError);
-        }
-    }
+			return true;
+		} catch (error) {
+			const customError = new EventTrackerError(error);
 
-    async createDatabaseFolder() {
-        try {
-            const folderPath = this.path;
-            return await RNFS.mkdir(folderPath)
-        } catch (error) {
-            const customError = new EventTrackerError(error);
+			return Promise.reject(customError);
+		}
+	}
 
-            return Promise.reject(customError);
-        }
-    }
-    
-    async _checkFolderCreation() {
-        const folderExist = await this.isFolderAvailable();
-        if(folderExist) {
-            return null;
-        }
+	async createDatabaseFolder() {
+		try {
+			const folderPath = this.path;
+			return await RNFS.mkdir(folderPath);
+		} catch (error) {
+			const customError = new EventTrackerError(error);
 
-        return await this.createDatabaseFolder()
-    }
+			return Promise.reject(customError);
+		}
+	}
+
+	async _checkFolderCreation() {
+		const folderExist = await this.isFolderAvailable();
+		if (folderExist) {
+			return null;
+		}
+
+		return await this.createDatabaseFolder();
+	}
 }
 
 export default Database;

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -3,368 +3,396 @@ import EventTrackerError from './event-tracker-error';
 import Database from './database';
 import Validations from '../utils/validations';
 import Helpers from '../utils/helpers';
-import { differenceInMilliseconds } from 'date-fns';
+import {differenceInMilliseconds} from 'date-fns';
 
 /**
  * Manages events, including adding, retrieving, and validating them.
- * 
+ *
  * @class
  * @description The `EventTracker` class provides functionality for managing events, including adding new events,
  *              validating event sequences, and retrieving event data. It interacts with the `Database` class to
  *              perform operations on the event records.
  */
 
-
-class EventTracker{
-
-    /**
-     * @param {string} filename - The name of the database file used by the `EventTracker` instance.
-     */
-
-    constructor(filename) {
-        this.db = new Database(filename);
-    }
-
-    /**
-     * Adds an event to the database after performing validations.
-     * 
-     * @async
-     * @name addEvent
-     * @param {{id: string, type: string, time: string, payload: object}} params
-     * @param {string} params.id 
-     * @param {"start"|"pause"|"resume"|"finish"}  params.type
-     * @param {string} params.time current time in isoString format
-     * @param {object} params.payload any data that you want to save associated with the id and type
-     * @returns {Promise<{id: string, time: number}>} A promise that resolves to an object containing the `id` of the event and the `time` the event was created.
-     * @throws {Error} If any validation fails or the event cannot be saved to the database.
-     */
-
-    async addEvent(params) {
-        try {
-            const {id, type, time, payload} = params;
-            await Validations.idValidation(id);
-            
-            await this._eventValidation(id, type)
-
-            const createdEvent = Event.create(id, type, time, payload);
-
-            await this.db.save(createdEvent);
-
-            return {
-                id,
-                time: createdEvent.time,
-            }
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }
-
-     /**
-     * @name getEventsById
-     * @description This method allows you to obtain all the events related to the id
-     * @param {string} id 
-     * @returns {Promise<{id: string, time: string, payload: object, type: string}[]}>}
-     */
-
-    async getEventsById (id) {
-        try {
-            await Validations.idValidation(id);
-
-            const filters = Helpers.getFilters({id});
-
-            const events = await this.db.search(filters,id);
-            
-            return events.map((e) => Event.parseEventFromDB(e));
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }
-
-    /**
-     * Retrieves the last event associated with a given ID.
-     * 
-     * @name getLastEventById 
-     * @param {string} id - The ID for which to retrieve the last event type.
-     * @returns {Promise<{id: string, time: string, payload: object, type: string}>} A promise that resolves to the last event, or an empty string if no event is found.
-     * @throws {Error} If the ID is invalid or an error occurs during the search process.
-     */
-
-    async getLastEventById(id) {
-        try {
-            await Validations.idValidation(id);
-        
-            const filters = Helpers.getFilters({id});
-            const events = await this.db.search(filters, id)
-            let registerEvents = Helpers.reverseArray(events);
-            const findedEvent = registerEvents[0];
-            
-            if(!findedEvent) return {};
-
-            return Event.parseEventFromDB(findedEvent);
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }   
-
-     /**
-     *  Calculates the elapsed time between the start and finish events.
-     *  When not receive  finish time, it calculates the difference with the current time
-     * 
-     * @name getElapsedTime
-     * @param {{startTime, finishTime, format}} param
-     * @param {string} startTime start time in iso string format
-     * @param {string} finishTime finish time in iso string format
-     * @param {boolean} format if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
-     * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated elapsed time
-     */
-
-
-    getElapsedTime ({
-        startTime,
-        finishTime, 
-        format = true
-        }) {
-        
-        if(!startTime) return format ? {
-            days:0,
-            hours: 0,
-            minutes: 0,
-            seconds: 0,
-        } : 0;
-
-        const lastTime = !!finishTime ? finishTime : new Date().toISOString();
-
-        return Helpers.getTimeDifference(startTime, lastTime, format);
-    }
-
-    /**
-     *  Calculates the time elapsed between each pause and resume of an id.
-     * 
-     * @name getStoppedTime
-     * @param {{id: string, time: string, payload: object, type: string}[]} events events associated with an id
-     * @param {boolean} format if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
-     * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated stopped time
-    */
-
-    //istanbul ignore next
-    getStoppedTime ({events = [], format = false}) {
-        if(!events?.length || !Helpers.isArray(events)) return 0;
-
-        const stoppedTime = events.reduce((totalPausedTime, currentEvent, index) => {
-            if(currentEvent.type !== 'pause') return totalPausedTime;
-
-            let nextEvent = events[index + 1] || {};
-
-            if(nextEvent.type === 'pause') return totalPausedTime;
-
-            if(nextEvent.type !== 'resume' && nextEvent.type !== 'finish') {
-                nextEvent.time = new Date();
-            }
-
-            const resumeTime = new Date(nextEvent.time);
-            const pauseTime = new Date(currentEvent.time);
-            const timeDifference = differenceInMilliseconds(resumeTime, pauseTime);
-
-            return totalPausedTime + timeDifference;
-        }, 0)
-
-        if(format) return Helpers.convertMillisecondsToTime(stoppedTime);
-        
-        return stoppedTime;
-    }
-
-    /**
-     * Calculates the net time between start and finish, discounting pauses
-     * 
-     * @name getNetTrackingTime
-     * @param {string} events tracked events 
-     * @param {boolean} format if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
-     * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated net time
-    */
-
-    getNetTrackingTime ({events = [], format = false}) {
-        if(!events?.length || !Helpers.isArray(events)) return 0;
-    
-        const startEvent = Helpers.findEventByStatus(events,'start');
-        const finishEvent = Helpers.findEventByStatus(events, 'finish');
-        const elapsedTime = this.getElapsedTime({
-            startTime: startEvent?.time,
-            finishTime: finishEvent?.time,
-            format: false,
-        })
-
-        if(!elapsedTime || elapsedTime <= 0) return 0;
-
-        const stoppedTime = this.getStoppedTime({events});
-        const netTime = elapsedTime - stoppedTime;
-
-        if(format) return Helpers.convertMillisecondsToTime(netTime);
-
-        return netTime;
-    }
-
-    /**
-     * Checks if an event with the given ID has already started.
-     * 
-     * @async
-     * @name isEventStarted
-     * @description This method searches for a "start" event associated with the provided ID. 
-     *              If a start event is found, it returns `true`, indicating the event has already started.
-     *              If no start event is found, it returns `false`.
-     * @param {string} id - The ID of the event to check.
-     * @returns {Promise<boolean>} A promise that resolves to `true` if a start event exists, or `false` if not.
-     * @throws {EventTrackerError} If the ID is invalid.
-     * @throws {Error} If an error occurs during the search process.
-     */
-
-    async isEventStarted (id) {
-        try {
-            await Validations.idValidation(id);
-
-            const filters = Helpers.getFilters({id,type: 'start'})
-
-            const startEvents = await this.db.search(filters, id, 'start');
-
-            if(!startEvents.length) return false;
-
-           return true;
-
-        } catch (error) {
-            return Promise.reject(error)
-        }
-    }
-
-    /**
-     * Deletes all events associated with the given ID from the database.
-     * 
-     * @async
-     * @name deleteEventsById
-     * @description This method deletes all events related to the specified ID by applying filters to the database query.
-     * @param {string} id - The ID of the events to be deleted.
-     * @returns {Promise<void>} A promise that resolves when the events are successfully deleted.
-     * @throws {EventTrackerError} If the ID is invalid.
-     * @throws {Error} If an error occurs during the deletion process.
-     */
-
-    async deleteEventsById (id) {
-        try {
-            await Validations.idValidation(id);
-
-            const filters = Helpers.getFilters({id});
-
-            await this.db.delete(filters, id);
-            
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }
-
-    /**
-    * Delete all records from the database 
-    * @name deleteAllEvents
-    * @returns {Promise<void>} A promise that resolves when the events are successfully deleted.
-    */
-    async deleteAllEvents () {
-        try {
-            await this.db.deleteAll();
-        } catch(error) {
-            return Promise.reject(error);
-        }
-    }
-
-    /**
-     * Asynchronously removes a record with the specified `id` and type 'finish' from the database.
-     *
-     * @param {string} id - The unique identifier of the record to be removed.
-     * @returns {Promise<boolean>} - A promise that resolves to `true` if the deletion was successful.
-     * @throws {Error} - If an error occurs during the deletion process, the promise is rejected with the error.
-     */
-
-    async removeFinishById (id) {
-        try {
-            const dbFilters = 'id LIKE[c] $0 && type = $1'
-            return await this.db.delete(dbFilters, String(id), 'finish');
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }
-
-    /**
-     * Validates the event type and checks if it follows the correct sequence for the given ID.
-     * 
-     * @async
-     * @private
-     * @name _eventValidation
-     * @description This method first validates the event type to ensure it is valid. It then retrieves the type of the last event 
-     *              associated with the provided ID and checks if the new event type follows the correct sequence.
-     * @param {string} id - The ID of the event to validate.
-     * @param {string} type - The type of the new event to validate.
-     * @returns {Promise<boolean>} A promise that resolves to `true` if the event type is valid and follows the correct sequence, 
-     *                             or `false` otherwise.
-     * @throws {EventTrackerError} If the event type is invalid or if the event sequence is incorrect.
-     * @throws {Error} If an error occurs during the validation process.
-     */
-
-    async _eventValidation (id,type) {
-        if(!Validations.isValidEventType(type)) throw new EventTrackerError('Event type is invalid')
-
-        const {type:previousType} = await this.getLastEventById(id)
-
-        return Validations.validateEventsSequence(type, previousType);
-    }
-
-    /**
-     * Retrieves the `time` property of the last event matching the specified ID and type.
-     *
-     * @async
-     * @param {string|number} id - The identifier used to filter events.
-     * @param {string} type - The type used to filter events.
-     * @returns {Promise<number|null>} Resolves with the `time` property of the last matching event, or `null` if no valid event is found.
-     * @throws {Error} If an error occurs during the search process, the promise is rejected with the error.
-     */
-
-    async getIdTimeByType (id,type) {
-        try {
-
-            await Validations.idValidation(id);
-
-            const isValidType = Validations.isValidEventType(type);
-            if(!isValidType) throw new EventTrackerError('Event type is invalid')
-            
-            const filters = Helpers.getFilters({id, type});
-
-            const filteredEvents = await this.db.search(filters, id, type);
-
-            const lastIndex = filteredEvents.length - 1;
-            const event = filteredEvents[lastIndex];
-            const parsedEvent = Event.parseEventFromDB(event);
-
-            if(!Helpers.isObject(parsedEvent) || !parsedEvent["time"]) return null;
-
-            return parsedEvent["time"];
-
-        } catch (error) {
-            return Promise.reject(error);
-        }
-    }
-
-    /**
-     * Deletes the database folder and updates the folder existence flag.
-     *
-     * @async
-     * @returns {Promise<void>} Resolves when the database folder is successfully removed.
-     * @throws {Error} If an error occurs during the folder removal process, the promise is rejected with the error.
-     */
-
-    async removeEventsFolder () {
-        try {
-            await this.db.removeDatabaseFolder();
-
-            return true;
-        } catch (error) {
-            return Promise.reject(error)
-        }
-    }
+class EventTracker {
+	/**
+	 * @param {string} filename - The name of the database file used by the `EventTracker` instance.
+	 */
+
+	constructor(filename) {
+		this.db = new Database(filename);
+	}
+
+	/**
+	 * Adds an event to the database after performing validations.
+	 *
+	 * @async
+	 * @name addEvent
+	 * @param {{id: string, type: string, time: string, payload: object}} params
+	 * @param {string} params.id
+	 * @param {"start"|"pause"|"resume"|"finish"}  params.type
+	 * @param {string} params.time current time in isoString format
+	 * @param {object} params.payload any data that you want to save associated with the id and type
+	 * @returns {Promise<{id: string, time: number}>} A promise that resolves to an object containing the `id` of the event and the `time` the event was created.
+	 * @throws {Error} If any validation fails or the event cannot be saved to the database.
+	 */
+
+	async addEvent(params) {
+		try {
+			const {id, type, time, payload} = params;
+			await Validations.idValidation(id);
+
+			await this._eventValidation(id, type);
+
+			const createdEvent = Event.create(id, type, time, payload);
+
+			await this.db.save(createdEvent);
+
+			return {
+				id,
+				time: createdEvent.time,
+			};
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	/**
+	 * @name getEventsById
+	 * @description This method allows you to obtain all the events related to the id
+	 * @param {string} id
+	 * @returns {Promise<{id: string, time: string, payload: object, type: string}[]}>}
+	 */
+
+	async getEventsById(id) {
+		try {
+			await Validations.idValidation(id);
+
+			const filters = Helpers.getFilters({id});
+
+			const events = await this.db.search(filters, id);
+
+			return events.map((e) => Event.parseEventFromDB(e));
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	/**
+	 * Retrieves the last event associated with a given ID.
+	 *
+	 * @name getLastEventById
+	 * @param {string} id - The ID for which to retrieve the last event type.
+	 * @returns {Promise<{id: string, time: string, payload: object, type: string}>} A promise that resolves to the last event, or an empty string if no event is found.
+	 * @throws {Error} If the ID is invalid or an error occurs during the search process.
+	 */
+
+	async getLastEventById(id) {
+		try {
+			await Validations.idValidation(id);
+
+			const filters = Helpers.getFilters({id});
+			const events = await this.db.search(filters, id);
+			let registerEvents = Helpers.reverseArray(events);
+			const findedEvent = registerEvents[0];
+
+			if (!findedEvent) return {};
+
+			return Event.parseEventFromDB(findedEvent);
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	/**
+	 *  Calculates the elapsed time between the start and finish events.
+	 *  When not receive  finish time, it calculates the difference with the current time
+	 *
+	 * @name getElapsedTime
+	 * @param {{startTime, finishTime, format}} param
+	 * @param {string} startTime start time in iso string format
+	 * @param {string} finishTime finish time in iso string format
+	 * @param {boolean} format if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
+	 * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated elapsed time
+	 */
+
+	getElapsedTime({startTime, finishTime, format = true}) {
+		if (!startTime)
+			return format
+				? {
+						days: 0,
+						hours: 0,
+						minutes: 0,
+						seconds: 0,
+					}
+				: 0;
+
+		const lastTime = !!finishTime ? finishTime : new Date().toISOString();
+
+		return Helpers.getTimeDifference(startTime, lastTime, format);
+	}
+
+	/**
+	 *  Calculates the time elapsed between each pause and resume of an id.
+	 *
+	 * @name getStoppedTime
+	 * @param {{id: string, time: string, payload: object, type: string}[]} events events associated with an id
+	 * @param {boolean} format if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
+	 * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated stopped time
+	 */
+
+	//istanbul ignore next
+	getStoppedTime({events = [], format = false}) {
+		if (!events?.length || !Helpers.isArray(events)) return 0;
+
+		const stoppedTime = events.reduce((totalPausedTime, currentEvent, index) => {
+			if (currentEvent.type !== 'pause') return totalPausedTime;
+
+			let nextEvent = events[index + 1] || {};
+
+			if (nextEvent.type === 'pause') return totalPausedTime;
+
+			if (nextEvent.type !== 'resume' && nextEvent.type !== 'finish') {
+				nextEvent.time = new Date();
+			}
+
+			const resumeTime = new Date(nextEvent.time);
+			const pauseTime = new Date(currentEvent.time);
+			const timeDifference = differenceInMilliseconds(resumeTime, pauseTime);
+
+			return totalPausedTime + timeDifference;
+		}, 0);
+
+		if (format) return Helpers.convertMillisecondsToTime(stoppedTime);
+
+		return stoppedTime;
+	}
+
+	/**
+	 * Calculates the net time between start and finish, discounting pauses
+	 *
+	 * @name getNetTrackingTime
+	 * @param {string} events tracked events
+	 * @param {boolean} format if true, returns the time in days-hours-minutes-seconds format, otherwise returns only the milliseconds
+	 * @returns {{days: number, hours: number ,minutes: number, seconds: number}} formated net time
+	 */
+
+	getNetTrackingTime({events = [], format = false}) {
+		if (!events?.length || !Helpers.isArray(events)) return 0;
+
+		const startEvent = Helpers.findEventByStatus(events, 'start');
+		const finishEvent = Helpers.findEventByStatus(events, 'finish');
+		const elapsedTime = this.getElapsedTime({
+			startTime: startEvent?.time,
+			finishTime: finishEvent?.time,
+			format: false,
+		});
+
+		if (!elapsedTime || elapsedTime <= 0) return 0;
+
+		const stoppedTime = this.getStoppedTime({events});
+		const netTime = elapsedTime - stoppedTime;
+
+		if (format) return Helpers.convertMillisecondsToTime(netTime);
+
+		return netTime;
+	}
+
+	/**
+	 * Checks if an event with the given ID has already started.
+	 *
+	 * @async
+	 * @name isEventStarted
+	 * @description This method searches for a "start" event associated with the provided ID.
+	 *              If a start event is found, it returns `true`, indicating the event has already started.
+	 *              If no start event is found, it returns `false`.
+	 * @param {string} id - The ID of the event to check.
+	 * @returns {Promise<boolean>} A promise that resolves to `true` if a start event exists, or `false` if not.
+	 * @throws {EventTrackerError} If the ID is invalid.
+	 * @throws {Error} If an error occurs during the search process.
+	 */
+
+	async isEventStarted(id) {
+		try {
+			await Validations.idValidation(id);
+
+			const filters = Helpers.getFilters({id, type: 'start'});
+
+			const startEvents = await this.db.search(filters, id, 'start');
+
+			if (!startEvents.length) return false;
+
+			return true;
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	/**
+	 * Generic search method that can be applied to any situation.
+	 * Allows searching events with custom queries and parameters.
+	 *
+	 * @async
+	 * @name searchEventByQuery
+	 * @description This method provides a flexible way to search events using custom queries and parameters.
+	 *              It delegates the search operation to the database layer while providing error handling.
+	 * @param {string} query - The search query/filter to apply. Can be empty for all events.
+	 * @param {...any} values - Variable number of values to use in the query (for parameterized queries).
+	 * @returns {Promise<Array>} A promise that resolves to an array of matching events.
+	 * @throws {EventTrackerError} If the database filename is not specified or other database errors occur.
+	 * @example
+	 * // Search all events
+	 * const allEvents = await eventTracker.searchEventByQuery();
+	 *
+	 * // Search by ID
+	 * const eventsById = await eventTracker.searchEventByQuery('id == $0', 'user123');
+	 *
+	 * // Search by type
+	 * const startEvents = await eventTracker.searchEventByQuery('type == $0', 'start');
+	 *
+	 * // Complex query
+	 * const recentEvents = await eventTracker.searchEventByQuery(
+	 *   'id == $0 && type == $1 && time >= $2',
+	 *   'user123', 'start', new Date('2024-01-01')
+	 * );
+	 */
+
+	async searchEventByQuery(query = '', ...values) {
+		try {
+			return await this.db.search(query, ...values);
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	/**
+	 * Deletes all events associated with the given ID from the database.
+	 *
+	 * @async
+	 * @name deleteEventsById
+	 * @description This method deletes all events related to the specified ID by applying filters to the database query.
+	 * @param {string} id - The ID of the events to be deleted.
+	 * @returns {Promise<void>} A promise that resolves when the events are successfully deleted.
+	 * @throws {EventTrackerError} If the ID is invalid.
+	 * @throws {Error} If an error occurs during the deletion process.
+	 */
+
+	async deleteEventsById(id) {
+		try {
+			await Validations.idValidation(id);
+
+			const filters = Helpers.getFilters({id});
+
+			await this.db.delete(filters, id);
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	/**
+	 * Delete all records from the database
+	 * @name deleteAllEvents
+	 * @returns {Promise<void>} A promise that resolves when the events are successfully deleted.
+	 */
+	async deleteAllEvents() {
+		try {
+			await this.db.deleteAll();
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	/**
+	 * Asynchronously removes a record with the specified `id` and type 'finish' from the database.
+	 *
+	 * @param {string} id - The unique identifier of the record to be removed.
+	 * @returns {Promise<boolean>} - A promise that resolves to `true` if the deletion was successful.
+	 * @throws {Error} - If an error occurs during the deletion process, the promise is rejected with the error.
+	 */
+
+	async removeFinishById(id) {
+		try {
+			const dbFilters = 'id LIKE[c] $0 && type = $1';
+			return await this.db.delete(dbFilters, String(id), 'finish');
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	/**
+	 * Validates the event type and checks if it follows the correct sequence for the given ID.
+	 *
+	 * @async
+	 * @private
+	 * @name _eventValidation
+	 * @description This method first validates the event type to ensure it is valid. It then retrieves the type of the last event
+	 *              associated with the provided ID and checks if the new event type follows the correct sequence.
+	 * @param {string} id - The ID of the event to validate.
+	 * @param {string} type - The type of the new event to validate.
+	 * @returns {Promise<boolean>} A promise that resolves to `true` if the event type is valid and follows the correct sequence,
+	 *                             or `false` otherwise.
+	 * @throws {EventTrackerError} If the event type is invalid or if the event sequence is incorrect.
+	 * @throws {Error} If an error occurs during the validation process.
+	 */
+
+	async _eventValidation(id, type) {
+		if (!Validations.isValidEventType(type)) throw new EventTrackerError('Event type is invalid');
+
+		const {type: previousType} = await this.getLastEventById(id);
+
+		return Validations.validateEventsSequence(type, previousType);
+	}
+
+	/**
+	 * Retrieves the `time` property of the last event matching the specified ID and type.
+	 *
+	 * @async
+	 * @param {string|number} id - The identifier used to filter events.
+	 * @param {string} type - The type used to filter events.
+	 * @returns {Promise<number|null>} Resolves with the `time` property of the last matching event, or `null` if no valid event is found.
+	 * @throws {Error} If an error occurs during the search process, the promise is rejected with the error.
+	 */
+
+	async getIdTimeByType(id, type) {
+		try {
+			await Validations.idValidation(id);
+
+			const isValidType = Validations.isValidEventType(type);
+			if (!isValidType) throw new EventTrackerError('Event type is invalid');
+
+			const filters = Helpers.getFilters({id, type});
+
+			const filteredEvents = await this.db.search(filters, id, type);
+
+			const lastIndex = filteredEvents.length - 1;
+			const event = filteredEvents[lastIndex];
+			const parsedEvent = Event.parseEventFromDB(event);
+
+			if (!Helpers.isObject(parsedEvent) || !parsedEvent['time']) return null;
+
+			return parsedEvent['time'];
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	/**
+	 * Deletes the database folder and updates the folder existence flag.
+	 *
+	 * @async
+	 * @returns {Promise<void>} Resolves when the database folder is successfully removed.
+	 * @throws {Error} If an error occurs during the folder removal process, the promise is rejected with the error.
+	 */
+
+	async removeEventsFolder() {
+		try {
+			await this.db.removeDatabaseFolder();
+
+			return true;
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
 }
 
-export default EventTracker; 
+export default EventTracker;


### PR DESCRIPTION
## LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/APPSRN-399

## DESCRIPCIÓN DEL REQUERIMIENTO:

### CONTEXTO:

Actulalmente, el pkg de event-tracker cuenta con métodos de búsqueda que sólo se adaptan a casos puntuales, lo que dificulta usarlos de maneras más flexibles. Esto se debe a que, hasta ahora, no fue necesario ajustar la búsqueda en la DB. Sin embargo, ahora se requiere que la clase de EventTracker exponga un método mediante el cuál se pueda realizar una búsqueda personalizada.

### NECESIDAD:

Se requiere agregar un nuevo método en la clase de tracking que reciba, como argumentos:
- una query custom para aplicar sobre la base de datos
- argumentos extra para aplicar junto a la query para realizar la búsqueda.

## DESCRIPCIÓN DE LA SOLUCIÓN:

Se agregó el método `searchEventByQuery`que está pensada para adaptarse a cualquier situación de busqueda ya que, básicamente, es igual a la función search de `database`, la cuál recibe una query y argumentos para realizar una busqueda en la base de datos.

También, se eliminó la restrición del método search en database que obligaba a que el pase parametros además de la query. Esto permitirá el método sea más flexible y pueda aplicar filtros de busqueda sin necesidad de que estos tengan placeholders.

## ¿CÓMO PROBARLO?

Para probarla vincular el pkg al repositorio de picking, que ya cuenta con funcionalidades de tracking.
Luego, ir al flujo de picking e iniciar una nueva ronda pendiente (puede ser cualquiera siempre que tenga 2 o más items para pickear).

Luego de eso, agregar el siguiente código en la pantalla `Session.js`:

```js

const searchByQuery async () => {
 //obtendrá el evento de pausa asociado al id del producto
  await EventTracker.searchEventByQuery('id LIKE[c] $0 && type = $1', id, "pause") 
            .then((response) => console.log('stopped events', response))
            .catch((error) => console.log(error)); 

  //obtendrá todos los eventos cuyo id no coincida con el del producto
  await EventTracker.searchEventByQuery("id != $0", id)           
          .then((response) => console.log(response))
          .catch((error) => console.log(error))
}
```

Ejecute este método en un useEffect condicionado por la propiedad id asociado al currentItem de la pantalla Session.js
Debería obtener los registros correspondientes según cada prueba.

## DATOS EXTRA A TENER EN CUENTA:
Se aplicó un formateo de eslint de manera automática, por lo que se modificó todo el archivo. EL método que debe revisar es: `searchEventyByQuery` y sus test correspondientes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new search capability, allowing users to find events using custom queries with flexible parameters.

* **Tests**
  * Expanded test coverage to include scenarios for the new event search feature, ensuring accurate and reliable search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->