### PR TITLE
updated searchEventByQuery response

### DIFF
--- a/__test__/eventTracker.test.js
+++ b/__test__/eventTracker.test.js
@@ -363,7 +363,12 @@ describe('EventTracker class', () => {
 		describe('return all events when', () => {
 			it('no query is provided', async () => {
 				const mockEvents = [
-					{id: '123', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: '{}'},
+					{
+						id: '123',
+						type: 'start',
+						time: '2023-01-01T00:00:00.000Z',
+						payload: '{"userId":"123","warehouseId":"123-wh"}',
+					},
 					{id: '456', type: 'pause', time: '2023-01-01T00:00:10.000Z', payload: '{}'},
 				];
 				searchFn.mockResolvedValueOnce(mockEvents);
@@ -371,7 +376,15 @@ describe('EventTracker class', () => {
 				const response = await eventTracker.searchEventByQuery();
 
 				expect(searchFn).toHaveBeenCalledWith('', ...[]);
-				expect(response).toStrictEqual(mockEvents);
+				expect(response).toStrictEqual([
+					{
+						id: '123',
+						type: 'start',
+						time: '2023-01-01T00:00:00.000Z',
+						payload: {userId: '123', warehouseId: '123-wh'},
+					},
+					{id: '456', type: 'pause', time: '2023-01-01T00:00:10.000Z', payload: {}},
+				]);
 			});
 		});
 
@@ -386,7 +399,10 @@ describe('EventTracker class', () => {
 				const response = await eventTracker.searchEventByQuery('id == $0', '123');
 
 				expect(searchFn).toHaveBeenCalledWith('id == $0', '123');
-				expect(response).toStrictEqual(mockEvents);
+				expect(response).toStrictEqual([
+					{id: '123', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: {}},
+					{id: '123', type: 'pause', time: '2023-01-01T00:00:10.000Z', payload: {}},
+				]);
 			});
 
 			it('searching by type', async () => {
@@ -399,7 +415,10 @@ describe('EventTracker class', () => {
 				const response = await eventTracker.searchEventByQuery('type == $0', 'start');
 
 				expect(searchFn).toHaveBeenCalledWith('type == $0', 'start');
-				expect(response).toStrictEqual(mockEvents);
+				expect(response).toStrictEqual([
+					{id: '123', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: {}},
+					{id: '456', type: 'start', time: '2023-01-01T00:00:05.000Z', payload: {}},
+				]);
 			});
 
 			it('searching with complex query', async () => {
@@ -421,7 +440,33 @@ describe('EventTracker class', () => {
 					'start',
 					new Date('2023-01-01'),
 				);
-				expect(response).toStrictEqual(mockEvents);
+				expect(response).toStrictEqual([
+					{id: '123', type: 'start', time: '2023-01-01T00:00:00.000Z', payload: {}},
+				]);
+			});
+
+			it('searching with payload containing data', async () => {
+				const mockEvents = [
+					{
+						id: '123',
+						type: 'resume',
+						time: '2023-01-01T00:00:00.000Z',
+						payload: '{"userId":"123","warehouseId":"123-wh"}',
+					},
+				];
+				searchFn.mockResolvedValueOnce(mockEvents);
+
+				const response = await eventTracker.searchEventByQuery('id == $0', '123');
+
+				expect(searchFn).toHaveBeenCalledWith('id == $0', '123');
+				expect(response).toStrictEqual([
+					{
+						id: '123',
+						type: 'resume',
+						time: '2023-01-01T00:00:00.000Z',
+						payload: {userId: '123', warehouseId: '123-wh'},
+					},
+				]);
 			});
 		});
 

--- a/lib/event-tracker.js
+++ b/lib/event-tracker.js
@@ -259,7 +259,9 @@ class EventTracker {
 
 	async searchEventByQuery(query = '', ...values) {
 		try {
-			return await this.db.search(query, ...values);
+			const events = await this.db.search(query, ...values);
+
+			return events.map((e) => Event.parseEventFromDB(e));
 		} catch (error) {
 			return Promise.reject(error);
 		}


### PR DESCRIPTION
## LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/APPSRN-399

## CONTEXTO:
Revisando la respuesta de `searchEventByQuery` me di cuenta que la key `payload` de cada registro que se obtiene mediante este método es un **JSON** y no un **objeto**, lo que implica que, para poder acceder a los valores del payload, se necesita parsear esa información antes de utilizarla.

## NECESIDAD:
Corregir esta situación para que la información que se obtenga mediante `searchEventByQuery` ya venga parseada

## DESCRIPCIÓN DE LA SOLUCIÓN:
 Al igual que cuando usamos el método `getEventsById`, el método `searchEventByQuery`, luego de obtener la data desde la base de datos, toma el array de eventos obtenido y lo mapea para aplicar el método `parseEventFromDB` sobre cada uno de los eventos y que este contengan su payload en formato objeto en vez de JSON.
 
## ¿CÓMO PROBARLO?

Ejecutando los test y/o repitiendo los casos descriptos en el [PR en el que se agregó este método](https://github.com/janis-commerce/app-tracking-time/pull/10).

Corrobore que los eventos que reciba como respuesta de este método tengan su payload en formato objeto y no JSON.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event results now return payloads as parsed objects instead of JSON strings for all retrieval methods (query, by ID, by type). Empty payloads are consistently returned as {}. This ensures consistent, ready-to-use data across search results.

* **Tests**
  * Updated expectations across existing tests to reflect parsed payloads.
  * Added a new test validating payloads with data are correctly parsed into objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->